### PR TITLE
Add option to change "Additional Tags" to boxes alongside text

### DIFF
--- a/1080i/Includes_Info.xml
+++ b/1080i/Includes_Info.xml
@@ -250,11 +250,73 @@
         </definition>
     </include>
 
+    <include name="Info_Line_Pillbox_Object_Bordered">
+        <texturefocus colordiffuse="$PARAM[colordiffuse]" border="8">flags/blank-bordered.png</texturefocus>
+        <texturenofocus colordiffuse="$PARAM[colordiffuse]" border="8">flags/blank-bordered.png</texturenofocus>
+    </include>
+
+    <include name="Info_Line_Pillbox_Object">
+        <control type="button">
+            <include content="Info_Line_Pillbox_Object_Bordered">
+                <param name="colordiffuse">$PARAM[colordiffuse]</param>
+            </include>
+            <label fallback="$PARAM[label_fallback]">$PARAM[label]</label>
+            <haspath>$PARAM[haspath]</haspath>
+            <width>auto</width>
+            <textoffsetx>10</textoffsetx>
+            <textoffsety>info_tag_offset_y</textoffsety>
+            <aligny>top</aligny>
+            <font>font_infotag_bold</font>
+            <textcolor>$PARAM[textcolor]</textcolor>
+            <focusedcolor>$PARAM[textcolor]</focusedcolor>
+            <include>Dimension_Info_Line_Pillbox</include>
+            <shadowcolor>$PARAM[shadowcolor]</shadowcolor>
+            <nested />
+        </control>
+    </include>
+
+    <include name="Info_Line_Pillbox">
+        <include content="Info_Line_Pillbox_Object" condition="![Window.IsActive(VideoFullScreen.xml) | Window.IsActive(MusicVisualisation.xml)]">
+            <param name="colordiffuse">main_fg_30</param>
+            <param name="textcolor">main_fg_90</param>
+            <param name="shadowcolor">main_bg_12</param>
+            <param name="label">$PARAM[label]</param>
+            <param name="label_fallback">$PARAM[label_fallback]</param>
+            <param name="haspath">$PARAM[haspath]</param>
+            <nested />
+        </include>
+        <include content="Info_Line_Pillbox_Object" condition="Window.IsActive(VideoFullScreen.xml) | Window.IsActive(MusicVisualisation.xml)">
+            <param name="colordiffuse">panel_fg_30</param>
+            <param name="textcolor">panel_fg_90</param>
+            <param name="shadowcolor">panel_bg_12</param>
+            <param name="label">$PARAM[label]</param>
+            <param name="label_fallback">$PARAM[label_fallback]</param>
+            <param name="haspath">$PARAM[haspath]</param>
+            <nested />
+        </include>
+    </include>
+
     <include name="Info_Line_Label">
         <param name="haspath">false</param>
         <param name="dbtype_count">1</param>
         <definition>
-            <include content="Info_Line_Divider">
+            <include content="Info_Line_Divider" condition="!Skin.HasSetting(Info.EnablePillboxStyle)">
+                <include content="Info_Line_Visible_0$PARAM[dbtype_count]">
+                    <param name="condition">$PARAM[condition]</param>
+                    <param name="overrides">$PARAM[overrides]</param>
+                    <param name="container">$PARAM[container]</param>
+                    <param name="dbtype_01">$PARAM[dbtype_01]</param>
+                    <param name="dbtype_02">$PARAM[dbtype_02]</param>
+                    <param name="dbtype_03">$PARAM[dbtype_03]</param>
+                    <param name="dbtype_04">$PARAM[dbtype_04]</param>
+                    <param name="dbtype_05">$PARAM[dbtype_05]</param>
+                    <param name="dbtype_06">$PARAM[dbtype_06]</param>
+                </include>
+            </include>
+            <include content="Info_Line_Pillbox" condition="Skin.HasSetting(Info.EnablePillboxStyle)">
+                <param name="label">$PARAM[label]</param>
+                <param name="label_fallback">$PARAM[label_fallback]</param>
+                <param name="haspath">$PARAM[haspath]</param>
                 <include content="Info_Line_Visible_0$PARAM[dbtype_count]">
                     <param name="condition">$PARAM[condition]</param>
                     <param name="overrides">$PARAM[overrides]</param>
@@ -273,6 +335,7 @@
                 <textcolor>$PARAM[colordiffuse]_70</textcolor>
                 <width>auto</width>
                 <font>font_main</font>
+                <visible>!Skin.HasSetting(Info.EnablePillboxStyle)</visible>
                 <include content="Info_Line_Visible_0$PARAM[dbtype_count]">
                     <param name="condition">$PARAM[condition]</param>
                     <param name="overrides">$PARAM[overrides]</param>
@@ -495,9 +558,10 @@
         <param name="visible">true</param>
         <definition>
             <include content="Info_Line_Divider">
+                <visible>!Skin.HasSetting(Info.EnablePillboxStyle)</visible>
                 <visible>$PARAM[visible]</visible>
             </include>
-            <include content="Info_StarRating">
+            <include content="Info_StarRating" condition="!Skin.HasSetting(Info.EnablePillboxStyle)">
                 <param name="colordiffuse">$PARAM[colordiffuse]</param>
                 <param name="rating">$PARAM[rating]</param>
                 <left>-10</left>
@@ -507,6 +571,20 @@
                 <itemgap>-16</itemgap>
                 <visible>$PARAM[visible]</visible>
             </include>
+            <control type="group">
+                <visible>$PARAM[visible]</visible>
+                <visible>Skin.HasSetting(Info.EnablePillboxStyle)</visible>
+                <width>155</width>
+                <include>Dimension_Info_Line_Pillbox</include>
+                <control type="image">
+                    <texture colordiffuse="main_fg_30" border="8">flags/blank-bordered.png</texture>
+                </control>
+                <include content="Info_StarRating">
+                    <param name="colordiffuse">$PARAM[colordiffuse]</param>
+                    <param name="rating">$PARAM[rating]</param>
+                    <itemgap>-16</itemgap>
+                </include>
+            </control>
         </definition>
     </include>
 

--- a/1080i/Includes_Labels.xml
+++ b/1080i/Includes_Labels.xml
@@ -156,6 +156,11 @@
         <value>$LOCALIZE[39173] ($LOCALIZE[571])</value>
     </variable>
 
+    <variable name="Label_Setting_InfoLineStyle">
+        <value condition="Skin.HasSetting(Info.EnablePillboxStyle)">$LOCALIZE[31209]</value>
+        <value>$LOCALIZE[31329]</value>
+    </variable>
+
     <variable name="Label_Setting_ColourPreset">
         <value condition="$EXP[Exp_ColourPreset_BrightWhite]">$LOCALIZE[31560]</value>
         <value condition="$EXP[Exp_ColourPreset_MiamiVaporwave]">$LOCALIZE[31140]</value>

--- a/1080i/Includes_SkinSettings.xml
+++ b/1080i/Includes_SkinSettings.xml
@@ -616,11 +616,22 @@
             <param name="id">006</param>
             <label>$LOCALIZE[19033]</label>
         </include>
-        <include content="Settings_Button" description="Audio Channels">
+        <include content="Settings_Button" description="Infoline">
             <param name="dialog">false</param>
             <param name="window">skinsettings</param>
             <param name="baseid">$PARAM[baseid]</param>
             <param name="id">007</param>
+            <param name="control">button</param>
+            <param name="slevel">2</param>
+            <label>$LOCALIZE[31178]</label>
+            <label2>$VAR[Label_Setting_InfoLineStyle]</label2>
+            <onclick>Skin.ToggleSetting(Info.EnablePillboxStyle)</onclick>
+        </include>
+        <include content="Settings_Button" description="Audio Channels">
+            <param name="dialog">false</param>
+            <param name="window">skinsettings</param>
+            <param name="baseid">$PARAM[baseid]</param>
+            <param name="id">008</param>
             <param name="dialog">false</param>
             <param name="control">radiobutton</param>
             <label>$LOCALIZE[21444]</label>
@@ -631,7 +642,7 @@
             <param name="dialog">false</param>
             <param name="window">skinsettings</param>
             <param name="baseid">$PARAM[baseid]</param>
-            <param name="id">008</param>
+            <param name="id">009</param>
             <param name="dialog">false</param>
             <param name="control">radiobutton</param>
             <label>$LOCALIZE[31031]</label>
@@ -642,7 +653,7 @@
             <param name="dialog">false</param>
             <param name="window">skinsettings</param>
             <param name="baseid">$PARAM[baseid]</param>
-            <param name="id">009</param>
+            <param name="id">010</param>
             <param name="dialog">false</param>
             <param name="control">radiobutton</param>
             <label>$LOCALIZE[33067]</label>

--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -670,6 +670,10 @@ msgctxt "#31177"
 msgid "Menus"
 msgstr ""
 
+msgctxt "#31178"
+msgid "Info line"
+msgstr ""
+
 #: /1080i/Includes_Search.xml
 msgctxt "#31179"
 msgid "Keyword"


### PR DESCRIPTION
Hey @jurialmunkey, 😊

At the moment, the additional tags are only displayed as plain text. 
This pull request adds an option to display the additional tags as boxes instead, as was the case with Arctic Fuse 2.

Users can choose between text or boxed tags in the settings.

Related to:
https://github.com/jurialmunkey/skin.arctic.fuse.3/discussions/47

Here are a few previews / impressions...

***Text:***
<img width="1766" height="994" alt="Text" src="https://github.com/user-attachments/assets/d37b268c-6f5b-4547-aeab-850a4d2497e8" />

***Boxes:***
<img width="1766" height="994" alt="Boxes" src="https://github.com/user-attachments/assets/93b92526-803d-4435-8bfc-852952806fa1" />

***Settings:***
<img width="1766" height="994" alt="Settings" src="https://github.com/user-attachments/assets/d28026fb-927d-4aa1-b7a8-05b8ef15aefd" />