### PR TITLE
Sort recordings by date (PVR Hub)

### DIFF
--- a/1080i/Includes_LiveTV.xml
+++ b/1080i/Includes_LiveTV.xml
@@ -78,6 +78,8 @@
                 <param name="id">504</param>
                 <param name="target">tvrecordings</param>
                 <param name="content">pvr://recordings/tv/active?view=flat</param>
+                <param name="sortby">date</param>
+                <param name="sortorder">descending</param>
                 <param name="include">List_Landscape_Row</param>
                 <param name="visible">String.IsEqual(Container(601).ListItem.Property(guid),pvr-504)</param>
                 <param name="home_switcher">false</param>


### PR DESCRIPTION
Currently recordings show up in a random order in the recordings tab inside the home pvr hub. This pr changes the sort method to date and now the most recent recording is listed first and the oldest one will the last.

Before:
![fuse_3_recordings_before](https://github.com/user-attachments/assets/9b2dad48-4023-4914-b074-f580605bb3e0)

After:
![fuse_3_recordings_after](https://github.com/user-attachments/assets/3feddde4-9d7b-4c47-aa7c-25e24c90cc24)
