### PR TITLE
⚡ Update RottenTomatoes image var

### DIFF
--- a/1080i/Includes_Images.xml
+++ b/1080i/Includes_Images.xml
@@ -588,7 +588,8 @@
         <value condition="String.IsEqual(Window(Home).Property(TMDbHelper.Player.RottenTomatoes_Image),certified)">certified.png</value>
         <value condition="String.IsEqual(Window(Home).Property(TMDbHelper.Player.RottenTomatoes_Image),fresh)">rtfresh.png</value>
         <value condition="String.IsEqual(Window(Home).Property(TMDbHelper.Player.RottenTomatoes_Image),rotten)">rtrotten.png</value>
-        <value condition="Integer.IsGreater(Window(Home).Property(TMDbHelper.Player.RottenTomatoes_Rating),59)">rtfresh.png</value>
+        <value condition="Integer.IsGreater(Window(Home).Property(TMDbHelper.Player.RottenTomatoes_Rating),74)">certified.png</value>
+        <value condition="Integer.IsGreater(Window(Home).Property(TMDbHelper.Player.RottenTomatoes_Rating),59) | String.IsEmpty(Window(Home).Property(TMDbHelper.Player.RottenTomatoes_Rating))">rtfresh.png</value>
         <value>rtrotten.png</value>
     </variable>
 
@@ -596,7 +597,8 @@
         <value condition="String.IsEqual(Window(Home).Property(TMDbHelper.ListItem.RottenTomatoes_Image),certified)">certified.png</value>
         <value condition="String.IsEqual(Window(Home).Property(TMDbHelper.ListItem.RottenTomatoes_Image),fresh)">rtfresh.png</value>
         <value condition="String.IsEqual(Window(Home).Property(TMDbHelper.ListItem.RottenTomatoes_Image),rotten)">rtrotten.png</value>
-        <value condition="Integer.IsGreater(Window(Home).Property(TMDbHelper.ListItem.RottenTomatoes_Rating),59)">rtfresh.png</value>
+        <value condition="Integer.IsGreater(Window(Home).Property(TMDbHelper.ListItem.RottenTomatoes_Rating),74)">certified.png</value>
+        <value condition="Integer.IsGreater(Window(Home).Property(TMDbHelper.ListItem.RottenTomatoes_Rating),59) | String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.RottenTomatoes_Rating))">rtfresh.png</value>
         <value>rtrotten.png</value>
     </variable>
 


### PR DESCRIPTION
- Use `rottentomatoes_rating` > 74 to determine "certified" status for newer titles without `rottentomatoes_image` value

Related TMDb Helper PR: https://github.com/jurialmunkey/plugin.video.themoviedb.helper/pull/1799

The above TMDb Helper PR will fix the missing `rottentomatoes_image` value but you'll still get `N/A` for newer certified fresh titles (e.g. Project Hail Mary at the time of posting). This PR uses the `rottentomatoes_rating` value to mitigate that.

I still think `rottentomatoes_image` is a more reliable source to verify if a title is "certified fresh", so I decided to keep it as the primary condition and only use the `rottentomatoes_rating` value as a fallback.