### PR TITLE
⚡ Avoid info dialog button duplication

### DIFF
--- a/1080i/Custom_1119_Dialog_Select.xml
+++ b/1080i/Custom_1119_Dialog_Select.xml
@@ -5,8 +5,8 @@
     <controls>
         <include content="DialogCustom_Favourites">
             <param name="id">8000</param>
-            <param name="header">$LOCALIZE[31202]</param>
-            <param name="include_content">DialogCustom_Ratings_Items</param>
+            <param name="header">$INFO[Window(Home).Property(CustomDialogSelectTitle)]</param>
+            <param name="include_content">DialogCustom_Select_Items</param>
             <param name="include_list">DialogCustom_Settings_Grouplist</param>
             <param name="resize">true</param>
         </include>

--- a/1080i/Dialog_DialogCustom.xml
+++ b/1080i/Dialog_DialogCustom.xml
@@ -172,6 +172,11 @@
         <include condition="String.IsEqual(Window(Home).Property(CustomDialogSettingsItems),DialogCustom_GameOptions_Items)">DialogCustom_GameOptions_Items</include>
     </include>
 
+    <include name="DialogCustom_Select_Items">
+        <include condition="String.IsEqual(Window(Home).Property(CustomDialogSelectItems),DialogCustom_Ratings_Items)">DialogCustom_Ratings_Items</include>
+        <include condition="String.IsEqual(Window(Home).Property(CustomDialogSelectItems),DialogCustom_Buttons_Items_Select)">DialogCustom_Buttons_Items_Select</include>
+    </include>
+
     <include name="DialogCustom_Settings_Items_ColourPresets">
         <include content="Button_Dialog_Setting">
             <param name="dialog">true</param>
@@ -1232,13 +1237,136 @@
         </include>
     </include>
 
+    <include name="DialogCustom_Buttons_Items_Template">
+        <include content="Button_Dialog_Setting">
+            <param name="dialog">true</param>
+            <param name="id">$PARAM[id]</param>
+            <param name="groupid">$PARAM[groupid]</param>
+            <param name="control">radiobutton</param>
+            <param name="istext">true</param>
+            <param name="label">$PARAM[label]</param>
+            <onclick condition="Skin.String(DialogInfo.$PARAM[content].Item01,$PARAM[type])">Skin.SetString(DialogInfo.$PARAM[content].Item01,$INFO[Skin.String(DialogInfo.$PARAM[content].$PARAM[item])])</onclick>
+            <onclick condition="Skin.String(DialogInfo.$PARAM[content].Item02,$PARAM[type])">Skin.SetString(DialogInfo.$PARAM[content].Item02,$INFO[Skin.String(DialogInfo.$PARAM[content].$PARAM[item])])</onclick>
+            <onclick condition="Skin.String(DialogInfo.$PARAM[content].Item03,$PARAM[type])">Skin.SetString(DialogInfo.$PARAM[content].Item03,$INFO[Skin.String(DialogInfo.$PARAM[content].$PARAM[item])])</onclick>
+            <onclick>Skin.SetString(DialogInfo.$PARAM[content].$PARAM[item],$PARAM[type])</onclick>
+            <onclick>Close</onclick>
+            <selected>Skin.String(DialogInfo.$PARAM[content].$PARAM[item],$PARAM[type])</selected>
+        </include>
+    </include>
+
+    <include name="DialogCustom_Buttons_Items_Type">
+        <include content="DialogCustom_Buttons_Items_Template">
+            <param name="id">8002</param>
+            <param name="groupid">8102</param>
+            <param name="label">$LOCALIZE[31393]</param>
+            <param name="type">Trailer</param>
+            <param name="item">$PARAM[item]</param>
+            <param name="content">$PARAM[content]</param>
+        </include>
+        <include content="DialogCustom_Buttons_Items_Template">
+            <param name="id">8003</param>
+            <param name="groupid">8103</param>
+            <param name="label">Trakt</param>
+            <param name="type">Trakt</param>
+            <param name="item">$PARAM[item]</param>
+            <param name="content">$PARAM[content]</param>
+        </include>
+        <include content="DialogCustom_Buttons_Items_Template">
+            <param name="id">8004</param>
+            <param name="groupid">8104</param>
+            <param name="label">Wikipedia</param>
+            <param name="type">Wikipedia</param>
+            <param name="item">$PARAM[item]</param>
+            <param name="content">$PARAM[content]</param>
+        </include>
+        <include content="DialogCustom_Buttons_Items_Template">
+            <param name="id">8005</param>
+            <param name="groupid">8105</param>
+            <param name="label">$LOCALIZE[207]</param>
+            <param name="type">Plot</param>
+            <param name="item">$PARAM[item]</param>
+            <param name="content">$PARAM[content]</param>
+        </include>
+        <include content="DialogCustom_Buttons_Items_Template">
+            <param name="id">8006</param>
+            <param name="groupid">8106</param>
+            <param name="label">$LOCALIZE[39123]</param>
+            <param name="type">Artwork</param>
+            <param name="item">$PARAM[item]</param>
+            <param name="content">$PARAM[content]</param>
+        </include>
+        <include content="DialogCustom_Buttons_Items_Template">
+            <param name="id">8007</param>
+            <param name="groupid">8107</param>
+            <param name="label">$LOCALIZE[563]</param>
+            <param name="type">UserRating</param>
+            <param name="item">$PARAM[item]</param>
+            <param name="content">$PARAM[content]</param>
+        </include>
+        <include content="DialogCustom_Buttons_Items_Template">
+            <param name="id">8008</param>
+            <param name="groupid">8108</param>
+            <param name="label">$LOCALIZE[40000]</param>
+            <param name="type">Versions</param>
+            <param name="item">$PARAM[item]</param>
+            <param name="content">$PARAM[content]</param>
+        </include>
+        <include content="DialogCustom_Buttons_Items_Template">
+            <param name="id">8009</param>
+            <param name="groupid">8109</param>
+            <param name="label">$LOCALIZE[40211]</param>
+            <param name="type">Extras</param>
+            <param name="item">$PARAM[item]</param>
+            <param name="content">$PARAM[content]</param>
+        </include>
+        <include content="DialogCustom_Buttons_Items_Template">
+            <param name="id">8010</param>
+            <param name="groupid">8110</param>
+            <param name="label">$LOCALIZE[184]</param>
+            <param name="type">Refresh</param>
+            <param name="item">$PARAM[item]</param>
+            <param name="content">$PARAM[content]</param>
+        </include>
+    </include>
+
+    <include name="DialogCustom_Buttons_Items_Select">
+        <include content="DialogCustom_Buttons_Items_Type" condition="String.IsEqual(Window(Home).Property(ConfigureVideoInfoButtonItem),Item01) + String.IsEqual(Window(Home).Property(ConfigureVideoInfoButtonContent),Movies)">
+            <param name="item">Item01</param>
+            <param name="content">Movies</param>
+        </include>
+        <include content="DialogCustom_Buttons_Items_Type" condition="String.IsEqual(Window(Home).Property(ConfigureVideoInfoButtonItem),Item02) + String.IsEqual(Window(Home).Property(ConfigureVideoInfoButtonContent),Movies)">
+            <param name="item">Item02</param>
+            <param name="content">Movies</param>
+        </include>
+        <include content="DialogCustom_Buttons_Items_Type" condition="String.IsEqual(Window(Home).Property(ConfigureVideoInfoButtonItem),Item03) + String.IsEqual(Window(Home).Property(ConfigureVideoInfoButtonContent),Movies)">
+            <param name="item">Item03</param>
+            <param name="content">Movies</param>
+        </include>
+        <include content="DialogCustom_Buttons_Items_Type" condition="String.IsEqual(Window(Home).Property(ConfigureVideoInfoButtonItem),Item01) + String.IsEqual(Window(Home).Property(ConfigureVideoInfoButtonContent),Others)">
+            <param name="item">Item01</param>
+            <param name="content">Others</param>
+        </include>
+        <include content="DialogCustom_Buttons_Items_Type" condition="String.IsEqual(Window(Home).Property(ConfigureVideoInfoButtonItem),Item02) + String.IsEqual(Window(Home).Property(ConfigureVideoInfoButtonContent),Others)">
+            <param name="item">Item02</param>
+            <param name="content">Others</param>
+        </include>
+        <include content="DialogCustom_Buttons_Items_Type" condition="String.IsEqual(Window(Home).Property(ConfigureVideoInfoButtonItem),Item03) + String.IsEqual(Window(Home).Property(ConfigureVideoInfoButtonContent),Others)">
+            <param name="item">Item03</param>
+            <param name="content">Others</param>
+        </include>
+    </include>
+
     <include name="DialogCustom_Buttons_Item">
         <include content="Settings_Button">
             <param name="dialog">true</param>
             <param name="id">$PARAM[id]</param>
             <label>$LOCALIZE[31080] $PARAM[number]</label>
             <label2>$INFO[Skin.String(DialogInfo.$PARAM[type].Item$PARAM[number])]</label2>
-            <onclick>RunScript(script.skinvariables,run_dialog=select,list=Trailer / Trakt / Wikipedia / Plot / Artwork / UserRating / Versions / Extras / Refresh,separator=' / ',heading=$PARAM[type] $PARAM[number],"executebuiltin=Skin.SetString(DialogInfo.$PARAM[type].Item$PARAM[number],{v})")</onclick>
+            <onclick>SetProperty(CustomDialogSelectItems,DialogCustom_Buttons_Items_Select,Home)</onclick>
+            <onclick>SetProperty(CustomDialogSelectTitle,$PARAM[type]: $LOCALIZE[31080] $PARAM[number],Home)</onclick>
+            <onclick>SetProperty(ConfigureVideoInfoButtonItem,Item$PARAM[number],Home)</onclick>
+            <onclick>SetProperty(ConfigureVideoInfoButtonContent,$PARAM[type],Home)</onclick>
+            <onclick>ActivateWindow(1119)</onclick>
         </include>
     </include>
 
@@ -1291,6 +1419,8 @@
             <param name="id">8001</param>
             <label>$LOCALIZE[563] 01</label>
             <label2>$INFO[Skin.String(CustomRating.Movies.Item01)]</label2>
+            <onclick>SetProperty(CustomDialogSelectItems,DialogCustom_Ratings_Items,Home)</onclick>
+            <onclick>SetProperty(CustomDialogSelectTitle,$LOCALIZE[20342]: $LOCALIZE[563] 01,Home)</onclick>
             <onclick>SetProperty(ConfigureRatingItem,Item01,Home)</onclick>
             <onclick>SetProperty(ConfigureRatingContent,Movies,Home)</onclick>
             <onclick>ActivateWindow(1119)</onclick>
@@ -1301,6 +1431,8 @@
             <param name="id">8002</param>
             <label>$LOCALIZE[563] 02</label>
             <label2>$INFO[Skin.String(CustomRating.Movies.Item02)]</label2>
+            <onclick>SetProperty(CustomDialogSelectItems,DialogCustom_Ratings_Items,Home)</onclick>
+            <onclick>SetProperty(CustomDialogSelectTitle,$LOCALIZE[20342]: $LOCALIZE[563] 02,Home)</onclick>
             <onclick>SetProperty(ConfigureRatingItem,Item02,Home)</onclick>
             <onclick>SetProperty(ConfigureRatingContent,Movies,Home)</onclick>
             <onclick>ActivateWindow(1119)</onclick>
@@ -1311,6 +1443,8 @@
             <param name="id">8003</param>
             <label>$LOCALIZE[563] 03</label>
             <label2>$INFO[Skin.String(CustomRating.Movies.Item03)]</label2>
+            <onclick>SetProperty(CustomDialogSelectItems,DialogCustom_Ratings_Items,Home)</onclick>
+            <onclick>SetProperty(CustomDialogSelectTitle,$LOCALIZE[20342]: $LOCALIZE[563] 03,Home)</onclick>
             <onclick>SetProperty(ConfigureRatingItem,Item03,Home)</onclick>
             <onclick>SetProperty(ConfigureRatingContent,Movies,Home)</onclick>
             <onclick>ActivateWindow(1119)</onclick>
@@ -1323,6 +1457,8 @@
             <param name="id">8001</param>
             <label>$LOCALIZE[563] 01</label>
             <label2>$INFO[Skin.String(CustomRating.TVShows.Item01)]</label2>
+            <onclick>SetProperty(CustomDialogSelectItems,DialogCustom_Ratings_Items,Home)</onclick>
+            <onclick>SetProperty(CustomDialogSelectTitle,$LOCALIZE[20343]: $LOCALIZE[563] 01,Home)</onclick>
             <onclick>SetProperty(ConfigureRatingItem,Item01,Home)</onclick>
             <onclick>SetProperty(ConfigureRatingContent,TVShows,Home)</onclick>
             <onclick>ActivateWindow(1119)</onclick>
@@ -1333,6 +1469,8 @@
             <param name="id">8002</param>
             <label>$LOCALIZE[563] 02</label>
             <label2>$INFO[Skin.String(CustomRating.TVShows.Item02)]</label2>
+            <onclick>SetProperty(CustomDialogSelectItems,DialogCustom_Ratings_Items,Home)</onclick>
+            <onclick>SetProperty(CustomDialogSelectTitle,$LOCALIZE[20343]: $LOCALIZE[563] 02,Home)</onclick>
             <onclick>SetProperty(ConfigureRatingItem,Item02,Home)</onclick>
             <onclick>SetProperty(ConfigureRatingContent,TVShows,Home)</onclick>
             <onclick>ActivateWindow(1119)</onclick>
@@ -1343,6 +1481,8 @@
             <param name="id">8003</param>
             <label>$LOCALIZE[563] 03</label>
             <label2>$INFO[Skin.String(CustomRating.TVShows.Item03)]</label2>
+            <onclick>SetProperty(CustomDialogSelectItems,DialogCustom_Ratings_Items,Home)</onclick>
+            <onclick>SetProperty(CustomDialogSelectTitle,$LOCALIZE[20343]: $LOCALIZE[563] 03,Home)</onclick>
             <onclick>SetProperty(ConfigureRatingItem,Item03,Home)</onclick>
             <onclick>SetProperty(ConfigureRatingContent,TVShows,Home)</onclick>
             <onclick>ActivateWindow(1119)</onclick>


### PR DESCRIPTION
Hey Jurial!

Hope you're doing well!

I love the new modular button system in the AF3 info dialog (might copy it over to my mod soon 🤣) but I noticed that using a simple select dialog can cause button duplication (i.e., 2 Trakt buttons or 3 Wikipedia buttons). Also checked SV documentation but couldn't find if there's a way to add conditions to `executebuiltin` in `run=dialog_select`

This PR repurposes the ratings selection logic to avoid that (also renamed the dialog to `Custom_1119_Dialog_Select` to better reflect this change).

I have tried to keep the naming schema as close to what you do in AF3 as possible (took some getting used to after coming from AF1 & 2 haha) but I might have messed up in some places.

And for strings, I decided to keep the button label for UserRating as "Rating" (563) instead of "User rating"(31061) for a cleaner look.