### PR TITLE
Separate plotline for movie and tv; add options for film director and none

### DIFF
--- a/1080i/Includes_Info.xml
+++ b/1080i/Includes_Info.xml
@@ -930,14 +930,23 @@
             <visible>String.IsEqual($PARAM[container]$PARAM[listitem].DBType,movie) | String.IsEqual($PARAM[container]$PARAM[listitem].DBType,tvshow) | $PARAM[override]</visible>
             <height>$PARAM[height]</height>
             <control type="group">
-                <visible>[!String.IsEmpty($PARAM[container]$PARAM[listitem].Tagline) + !Skin.HasSetting(Plotline.EnableGenre)] | [!String.IsEmpty($PARAM[container]$PARAM[listitem].Genre) + Skin.HasSetting(Plotline.EnableGenre)]</visible>
+                <visible>[String.IsEqual($PARAM[container]$PARAM[listitem].DBType,movie) + [Skin.String(Plotline.Movies,Genre) | [String.IsEmpty(Skin.String(Plotline.Movies)) + Skin.HasSetting(Plotline.EnableGenre)]] + !String.IsEmpty($PARAM[container]$PARAM[listitem].Genre)] | [String.IsEqual($PARAM[container]$PARAM[listitem].DBType,movie) + Skin.String(Plotline.Movies,Director) + !String.IsEmpty($PARAM[container]$PARAM[listitem].Director)] | [String.IsEqual($PARAM[container]$PARAM[listitem].DBType,movie) + String.IsEmpty(Skin.String(Plotline.Movies)) + !Skin.HasSetting(Plotline.EnableGenre) + !String.IsEmpty($PARAM[container]$PARAM[listitem].Tagline)] | [String.IsEqual($PARAM[container]$PARAM[listitem].DBType,tvshow) + [Skin.String(Plotline.TV,Genre) | [String.IsEmpty(Skin.String(Plotline.TV)) + Skin.HasSetting(Plotline.EnableGenre)]] + !String.IsEmpty($PARAM[container]$PARAM[listitem].Genre)] | [String.IsEqual($PARAM[container]$PARAM[listitem].DBType,tvshow) + String.IsEmpty(Skin.String(Plotline.TV)) + !Skin.HasSetting(Plotline.EnableGenre) + !String.IsEmpty($PARAM[container]$PARAM[listitem].Tagline)]</visible>
+                <control type="label">
+                    <textcolor>$PARAM[colordiffuse]_90</textcolor>
+                    <label>$INFO[$PARAM[container]$PARAM[listitem].Director]</label>
+                    <left>40</left>
+                    <height>40</height>
+                    <font>font_main_bold</font>
+                    <visible>String.IsEqual($PARAM[container]$PARAM[listitem].DBType,movie) + Skin.String(Plotline.Movies,Director) + !String.IsEmpty($PARAM[container]$PARAM[listitem].Director)</visible>
+                    <width>$PARAM[width]</width>
+                </control>
                 <control type="label">
                     <textcolor>$PARAM[colordiffuse]_90</textcolor>
                     <label>$INFO[$PARAM[container]$PARAM[listitem].Tagline]</label>
                     <left>40</left>
                     <height>40</height>
                     <font>font_main_bold</font>
-                    <visible>!Skin.HasSetting(Plotline.EnableGenre)</visible>
+                    <visible>[String.IsEqual($PARAM[container]$PARAM[listitem].DBType,movie) + String.IsEmpty(Skin.String(Plotline.Movies)) + !Skin.HasSetting(Plotline.EnableGenre)] | [String.IsEqual($PARAM[container]$PARAM[listitem].DBType,tvshow) + String.IsEmpty(Skin.String(Plotline.TV)) + !Skin.HasSetting(Plotline.EnableGenre)]</visible>
                     <width>$PARAM[width]</width>
                 </control>
                 <control type="label">
@@ -947,7 +956,7 @@
                     <height>40</height>
                     <font>font_main_bold</font>
                     <width>$PARAM[width]</width>
-                    <visible>Skin.HasSetting(Plotline.EnableGenre)</visible>
+                    <visible>[String.IsEqual($PARAM[container]$PARAM[listitem].DBType,movie) + [Skin.String(Plotline.Movies,Genre) | [String.IsEmpty(Skin.String(Plotline.Movies)) + Skin.HasSetting(Plotline.EnableGenre)]]] | [String.IsEqual($PARAM[container]$PARAM[listitem].DBType,tvshow) + [Skin.String(Plotline.TV,Genre) | [String.IsEmpty(Skin.String(Plotline.TV)) + Skin.HasSetting(Plotline.EnableGenre)]]]</visible>
                 </control>
                 <include content="Info_Plot_TextBox">
                     <param name="label">$INFO[$PARAM[container]$PARAM[listitem].Plot]</param>
@@ -959,7 +968,7 @@
                 </include>
             </control>
             <control type="group">
-                <visible>![[!String.IsEmpty($PARAM[container]$PARAM[listitem].Tagline) + !Skin.HasSetting(Plotline.EnableGenre)] | [!String.IsEmpty($PARAM[container]$PARAM[listitem].Genre) + Skin.HasSetting(Plotline.EnableGenre)]]</visible>
+                <visible>![[String.IsEqual($PARAM[container]$PARAM[listitem].DBType,movie) + [Skin.String(Plotline.Movies,Genre) | [String.IsEmpty(Skin.String(Plotline.Movies)) + Skin.HasSetting(Plotline.EnableGenre)]] + !String.IsEmpty($PARAM[container]$PARAM[listitem].Genre)] | [String.IsEqual($PARAM[container]$PARAM[listitem].DBType,movie) + Skin.String(Plotline.Movies,Director) + !String.IsEmpty($PARAM[container]$PARAM[listitem].Director)] | [String.IsEqual($PARAM[container]$PARAM[listitem].DBType,movie) + String.IsEmpty(Skin.String(Plotline.Movies)) + !Skin.HasSetting(Plotline.EnableGenre) + !String.IsEmpty($PARAM[container]$PARAM[listitem].Tagline)] | [String.IsEqual($PARAM[container]$PARAM[listitem].DBType,tvshow) + [Skin.String(Plotline.TV,Genre) | [String.IsEmpty(Skin.String(Plotline.TV)) + Skin.HasSetting(Plotline.EnableGenre)]] + !String.IsEmpty($PARAM[container]$PARAM[listitem].Genre)] | [String.IsEqual($PARAM[container]$PARAM[listitem].DBType,tvshow) + String.IsEmpty(Skin.String(Plotline.TV)) + !Skin.HasSetting(Plotline.EnableGenre) + !String.IsEmpty($PARAM[container]$PARAM[listitem].Tagline)]]</visible>
                 <include content="Info_Plot_TextBox">
                     <param name="label">$INFO[$PARAM[container]$PARAM[listitem].Plot]</param>
                     <param name="colordiffuse">$PARAM[colordiffuse]</param>

--- a/1080i/Includes_Info.xml
+++ b/1080i/Includes_Info.xml
@@ -922,41 +922,17 @@
         </control>
     </include>
 
-    <include name="Info_Plot_Main">
-
-        <!-- Movie / TV -->
-        <control type="group">
-            <visible>$PARAM[visible]</visible>
-            <visible>String.IsEqual($PARAM[container]$PARAM[listitem].DBType,movie) | String.IsEqual($PARAM[container]$PARAM[listitem].DBType,tvshow) | $PARAM[override]</visible>
-            <height>$PARAM[height]</height>
+    <include name="Info_Plot_Main_Plotline">
+        <definition>
             <control type="group">
-                <visible>[String.IsEqual($PARAM[container]$PARAM[listitem].DBType,movie) + [Skin.String(Plotline.Movies,Genre) | [String.IsEmpty(Skin.String(Plotline.Movies)) + Skin.HasSetting(Plotline.EnableGenre)]] + !String.IsEmpty($PARAM[container]$PARAM[listitem].Genre)] | [String.IsEqual($PARAM[container]$PARAM[listitem].DBType,movie) + Skin.String(Plotline.Movies,Director) + !String.IsEmpty($PARAM[container]$PARAM[listitem].Director)] | [String.IsEqual($PARAM[container]$PARAM[listitem].DBType,movie) + String.IsEmpty(Skin.String(Plotline.Movies)) + !Skin.HasSetting(Plotline.EnableGenre) + !String.IsEmpty($PARAM[container]$PARAM[listitem].Tagline)] | [String.IsEqual($PARAM[container]$PARAM[listitem].DBType,tvshow) + [Skin.String(Plotline.TV,Genre) | [String.IsEmpty(Skin.String(Plotline.TV)) + Skin.HasSetting(Plotline.EnableGenre)]] + !String.IsEmpty($PARAM[container]$PARAM[listitem].Genre)] | [String.IsEqual($PARAM[container]$PARAM[listitem].DBType,tvshow) + String.IsEmpty(Skin.String(Plotline.TV)) + !Skin.HasSetting(Plotline.EnableGenre) + !String.IsEmpty($PARAM[container]$PARAM[listitem].Tagline)]</visible>
+                <visible>!String.IsEmpty($PARAM[container]$PARAM[listitem].$PARAM[infolabel])</visible>
                 <control type="label">
                     <textcolor>$PARAM[colordiffuse]_90</textcolor>
-                    <label>$INFO[$PARAM[container]$PARAM[listitem].Director]</label>
-                    <left>40</left>
-                    <height>40</height>
-                    <font>font_main_bold</font>
-                    <visible>String.IsEqual($PARAM[container]$PARAM[listitem].DBType,movie) + Skin.String(Plotline.Movies,Director) + !String.IsEmpty($PARAM[container]$PARAM[listitem].Director)</visible>
-                    <width>$PARAM[width]</width>
-                </control>
-                <control type="label">
-                    <textcolor>$PARAM[colordiffuse]_90</textcolor>
-                    <label>$INFO[$PARAM[container]$PARAM[listitem].Tagline]</label>
-                    <left>40</left>
-                    <height>40</height>
-                    <font>font_main_bold</font>
-                    <visible>[String.IsEqual($PARAM[container]$PARAM[listitem].DBType,movie) + String.IsEmpty(Skin.String(Plotline.Movies)) + !Skin.HasSetting(Plotline.EnableGenre)] | [String.IsEqual($PARAM[container]$PARAM[listitem].DBType,tvshow) + String.IsEmpty(Skin.String(Plotline.TV)) + !Skin.HasSetting(Plotline.EnableGenre)]</visible>
-                    <width>$PARAM[width]</width>
-                </control>
-                <control type="label">
-                    <textcolor>$PARAM[colordiffuse]_90</textcolor>
-                    <label>$INFO[$PARAM[container]$PARAM[listitem].Genre]</label>
+                    <label>$INFO[$PARAM[container]$PARAM[listitem].$PARAM[infolabel]]</label>
                     <left>40</left>
                     <height>40</height>
                     <font>font_main_bold</font>
                     <width>$PARAM[width]</width>
-                    <visible>[String.IsEqual($PARAM[container]$PARAM[listitem].DBType,movie) + [Skin.String(Plotline.Movies,Genre) | [String.IsEmpty(Skin.String(Plotline.Movies)) + Skin.HasSetting(Plotline.EnableGenre)]]] | [String.IsEqual($PARAM[container]$PARAM[listitem].DBType,tvshow) + [Skin.String(Plotline.TV,Genre) | [String.IsEmpty(Skin.String(Plotline.TV)) + Skin.HasSetting(Plotline.EnableGenre)]]]</visible>
                 </control>
                 <include content="Info_Plot_TextBox">
                     <param name="label">$INFO[$PARAM[container]$PARAM[listitem].Plot]</param>
@@ -967,8 +943,9 @@
                     <param name="top">40</param>
                 </include>
             </control>
+
             <control type="group">
-                <visible>![[String.IsEqual($PARAM[container]$PARAM[listitem].DBType,movie) + [Skin.String(Plotline.Movies,Genre) | [String.IsEmpty(Skin.String(Plotline.Movies)) + Skin.HasSetting(Plotline.EnableGenre)]] + !String.IsEmpty($PARAM[container]$PARAM[listitem].Genre)] | [String.IsEqual($PARAM[container]$PARAM[listitem].DBType,movie) + Skin.String(Plotline.Movies,Director) + !String.IsEmpty($PARAM[container]$PARAM[listitem].Director)] | [String.IsEqual($PARAM[container]$PARAM[listitem].DBType,movie) + String.IsEmpty(Skin.String(Plotline.Movies)) + !Skin.HasSetting(Plotline.EnableGenre) + !String.IsEmpty($PARAM[container]$PARAM[listitem].Tagline)] | [String.IsEqual($PARAM[container]$PARAM[listitem].DBType,tvshow) + [Skin.String(Plotline.TV,Genre) | [String.IsEmpty(Skin.String(Plotline.TV)) + Skin.HasSetting(Plotline.EnableGenre)]] + !String.IsEmpty($PARAM[container]$PARAM[listitem].Genre)] | [String.IsEqual($PARAM[container]$PARAM[listitem].DBType,tvshow) + String.IsEmpty(Skin.String(Plotline.TV)) + !Skin.HasSetting(Plotline.EnableGenre) + !String.IsEmpty($PARAM[container]$PARAM[listitem].Tagline)]]</visible>
+                <visible>String.IsEmpty($PARAM[container]$PARAM[listitem].$PARAM[infolabel])</visible>
                 <include content="Info_Plot_TextBox">
                     <param name="label">$INFO[$PARAM[container]$PARAM[listitem].Plot]</param>
                     <param name="colordiffuse">$PARAM[colordiffuse]</param>
@@ -977,6 +954,98 @@
                     <param name="width">$PARAM[width]</param>
                 </include>
             </control>
+        </definition>
+    </include>
+
+    <include name="Info_Plot_Main">
+
+        <!-- Movie -->
+        <control type="group">
+            <visible>$PARAM[visible]</visible>
+            <visible>String.IsEqual($PARAM[container]$PARAM[listitem].DBType,movie) | $PARAM[override]</visible>
+            <height>$PARAM[height]</height>
+
+            <!-- No Plotline -->
+            <include content="Info_Plot_TextBox"  condition="Skin.String(Plotline.Movie,None)">
+                <param name="label">$INFO[$PARAM[container]$PARAM[listitem].Plot]</param>
+                <param name="colordiffuse">$PARAM[colordiffuse]</param>
+                <param name="use_textbox">$PARAM[use_textbox]</param>
+                <param name="height">$PARAM[height]</param>
+                <param name="width">$PARAM[width]</param>
+            </include>
+
+            <!-- Director Plotline -->
+            <include content="Info_Plot_Main_Plotline" condition="Skin.String(Plotline.Movie,Director)">
+                <param name="infolabel">Director</param>
+                <param name="colordiffuse">$PARAM[colordiffuse]</param>
+                <param name="container">$PARAM[container]</param>
+                <param name="listitem">$PARAM[listitem]</param>
+                <param name="use_textbox">$PARAM[use_textbox]</param>
+                <param name="height">$PARAM[height]</param>
+                <param name="width">$PARAM[width]</param>
+            </include>
+
+            <!-- Genre Plotline -->
+            <include content="Info_Plot_Main_Plotline" condition="Skin.String(Plotline.Movie,Genre)">
+                <param name="infolabel">Genre</param>
+                <param name="colordiffuse">$PARAM[colordiffuse]</param>
+                <param name="container">$PARAM[container]</param>
+                <param name="listitem">$PARAM[listitem]</param>
+                <param name="use_textbox">$PARAM[use_textbox]</param>
+                <param name="height">$PARAM[height]</param>
+                <param name="width">$PARAM[width]</param>
+            </include>
+
+            <!-- Tagline Plotline-->
+            <include content="Info_Plot_Main_Plotline" condition="String.IsEmpty(Skin.String(Plotline.Movie))">
+                <param name="infolabel">Tagline</param>
+                <param name="colordiffuse">$PARAM[colordiffuse]</param>
+                <param name="container">$PARAM[container]</param>
+                <param name="listitem">$PARAM[listitem]</param>
+                <param name="use_textbox">$PARAM[use_textbox]</param>
+                <param name="height">$PARAM[height]</param>
+                <param name="width">$PARAM[width]</param>
+            </include>
+
+        </control>
+
+        <!-- TVShow -->
+        <control type="group">
+            <visible>$PARAM[visible]</visible>
+            <visible>![$PARAM[override]]</visible>
+            <visible>String.IsEqual($PARAM[container]$PARAM[listitem].DBType,tvshow)</visible>
+            <height>$PARAM[height]</height>
+
+            <!-- No Plotline -->
+            <include content="Info_Plot_TextBox"  condition="Skin.String(Plotline.TVShow,None)">
+                <param name="label">$INFO[$PARAM[container]$PARAM[listitem].Plot]</param>
+                <param name="colordiffuse">$PARAM[colordiffuse]</param>
+                <param name="use_textbox">$PARAM[use_textbox]</param>
+                <param name="height">$PARAM[height]</param>
+                <param name="width">$PARAM[width]</param>
+            </include>
+
+            <!-- Genre Plotline -->
+            <include content="Info_Plot_Main_Plotline" condition="Skin.String(Plotline.TVShow,Genre)">
+                <param name="infolabel">Genre</param>
+                <param name="colordiffuse">$PARAM[colordiffuse]</param>
+                <param name="container">$PARAM[container]</param>
+                <param name="listitem">$PARAM[listitem]</param>
+                <param name="use_textbox">$PARAM[use_textbox]</param>
+                <param name="height">$PARAM[height]</param>
+                <param name="width">$PARAM[width]</param>
+            </include>
+
+            <!-- Tagline Plotline-->
+            <include content="Info_Plot_Main_Plotline" condition="String.IsEmpty(Skin.String(Plotline.TVShow))">
+                <param name="infolabel">Tagline</param>
+                <param name="colordiffuse">$PARAM[colordiffuse]</param>
+                <param name="container">$PARAM[container]</param>
+                <param name="listitem">$PARAM[listitem]</param>
+                <param name="use_textbox">$PARAM[use_textbox]</param>
+                <param name="height">$PARAM[height]</param>
+                <param name="width">$PARAM[width]</param>
+            </include>
         </control>
 
         <!-- Season / Video / Album / Channel -->

--- a/1080i/Includes_Info.xml
+++ b/1080i/Includes_Info.xml
@@ -922,13 +922,13 @@
         </control>
     </include>
 
-    <include name="Info_Plot_Main_Plotline">
+    <include name="Info_Plot_Main_Plotline_Content">
         <definition>
             <control type="group">
-                <visible>!String.IsEmpty($PARAM[container]$PARAM[listitem].$PARAM[infolabel])</visible>
+                <visible>$PARAM[visible]</visible>
                 <control type="label">
                     <textcolor>$PARAM[colordiffuse]_90</textcolor>
-                    <label>$INFO[$PARAM[container]$PARAM[listitem].$PARAM[infolabel]]</label>
+                    <label>$PARAM[label]</label>
                     <left>40</left>
                     <height>40</height>
                     <font>font_main_bold</font>
@@ -945,7 +945,7 @@
             </control>
 
             <control type="group">
-                <visible>String.IsEmpty($PARAM[container]$PARAM[listitem].$PARAM[infolabel])</visible>
+                <visible>![$PARAM[visible]]</visible>
                 <include content="Info_Plot_TextBox">
                     <param name="label">$INFO[$PARAM[container]$PARAM[listitem].Plot]</param>
                     <param name="colordiffuse">$PARAM[colordiffuse]</param>
@@ -957,6 +957,65 @@
         </definition>
     </include>
 
+    <include name="Info_Plot_Main_Plotline">
+        <!-- No Plotline -->
+        <include content="Info_Plot_TextBox"  condition="Skin.String(Plotline.$PARAM[dbtype],None)">
+            <param name="label">$INFO[$PARAM[container]$PARAM[listitem].Plot]</param>
+            <param name="colordiffuse">$PARAM[colordiffuse]</param>
+            <param name="use_textbox">$PARAM[use_textbox]</param>
+            <param name="height">$PARAM[height]</param>
+            <param name="width">$PARAM[width]</param>
+        </include>
+
+        <!-- Episodes Plotline -->
+        <include content="Info_Plot_Main_Plotline_Content" condition="Skin.String(Plotline.$PARAM[dbtype],Episodes)">
+            <param name="label">$INFO[$PARAM[container]$PARAM[listitem].Property(totalepisodes),, $LOCALIZE[20453]]$INFO[$PARAM[container]$PARAM[listitem].Property(totalseasons), $LOCALIZE[31373] , $LOCALIZE[36905]]</param>
+            <param name="visible">!String.IsEmpty($PARAM[container]$PARAM[listitem].Property(totalepisodes))</param>
+            <param name="colordiffuse">$PARAM[colordiffuse]</param>
+            <param name="container">$PARAM[container]</param>
+            <param name="listitem">$PARAM[listitem]</param>
+            <param name="use_textbox">$PARAM[use_textbox]</param>
+            <param name="height">$PARAM[height]</param>
+            <param name="width">$PARAM[width]</param>
+        </include>
+
+        <!-- Director Plotline -->
+        <include content="Info_Plot_Main_Plotline_Content" condition="Skin.String(Plotline.$PARAM[dbtype],Director)">
+            <param name="label">$INFO[$PARAM[container]$PARAM[listitem].Director]</param>
+            <param name="visible">!String.IsEmpty($PARAM[container]$PARAM[listitem].Director)</param>
+            <param name="colordiffuse">$PARAM[colordiffuse]</param>
+            <param name="container">$PARAM[container]</param>
+            <param name="listitem">$PARAM[listitem]</param>
+            <param name="use_textbox">$PARAM[use_textbox]</param>
+            <param name="height">$PARAM[height]</param>
+            <param name="width">$PARAM[width]</param>
+        </include>
+
+        <!-- Genre Plotline -->
+        <include content="Info_Plot_Main_Plotline_Content" condition="Skin.String(Plotline.$PARAM[dbtype],Genre)">
+            <param name="label">$INFO[$PARAM[container]$PARAM[listitem].Genre]</param>
+            <param name="visible">!String.IsEmpty($PARAM[container]$PARAM[listitem].Genre)</param>
+            <param name="colordiffuse">$PARAM[colordiffuse]</param>
+            <param name="container">$PARAM[container]</param>
+            <param name="listitem">$PARAM[listitem]</param>
+            <param name="use_textbox">$PARAM[use_textbox]</param>
+            <param name="height">$PARAM[height]</param>
+            <param name="width">$PARAM[width]</param>
+        </include>
+
+        <!-- Tagline Plotline-->
+        <include content="Info_Plot_Main_Plotline_Content" condition="String.IsEmpty(Skin.String(Plotline.$PARAM[dbtype]))">
+            <param name="label">$INFO[$PARAM[container]$PARAM[listitem].Tagline]</param>
+            <param name="visible">!String.IsEmpty($PARAM[container]$PARAM[listitem].Tagline)</param>
+            <param name="colordiffuse">$PARAM[colordiffuse]</param>
+            <param name="container">$PARAM[container]</param>
+            <param name="listitem">$PARAM[listitem]</param>
+            <param name="use_textbox">$PARAM[use_textbox]</param>
+            <param name="height">$PARAM[height]</param>
+            <param name="width">$PARAM[width]</param>
+        </include>
+    </include>
+
     <include name="Info_Plot_Main">
 
         <!-- Movie -->
@@ -964,19 +1023,8 @@
             <visible>$PARAM[visible]</visible>
             <visible>String.IsEqual($PARAM[container]$PARAM[listitem].DBType,movie) | $PARAM[override]</visible>
             <height>$PARAM[height]</height>
-
-            <!-- No Plotline -->
-            <include content="Info_Plot_TextBox"  condition="Skin.String(Plotline.Movie,None)">
-                <param name="label">$INFO[$PARAM[container]$PARAM[listitem].Plot]</param>
-                <param name="colordiffuse">$PARAM[colordiffuse]</param>
-                <param name="use_textbox">$PARAM[use_textbox]</param>
-                <param name="height">$PARAM[height]</param>
-                <param name="width">$PARAM[width]</param>
-            </include>
-
-            <!-- Director Plotline -->
-            <include content="Info_Plot_Main_Plotline" condition="Skin.String(Plotline.Movie,Director)">
-                <param name="infolabel">Director</param>
+            <include content="Info_Plot_Main_Plotline">
+                <param name="dbtype">movie</param>
                 <param name="colordiffuse">$PARAM[colordiffuse]</param>
                 <param name="container">$PARAM[container]</param>
                 <param name="listitem">$PARAM[listitem]</param>
@@ -984,29 +1032,6 @@
                 <param name="height">$PARAM[height]</param>
                 <param name="width">$PARAM[width]</param>
             </include>
-
-            <!-- Genre Plotline -->
-            <include content="Info_Plot_Main_Plotline" condition="Skin.String(Plotline.Movie,Genre)">
-                <param name="infolabel">Genre</param>
-                <param name="colordiffuse">$PARAM[colordiffuse]</param>
-                <param name="container">$PARAM[container]</param>
-                <param name="listitem">$PARAM[listitem]</param>
-                <param name="use_textbox">$PARAM[use_textbox]</param>
-                <param name="height">$PARAM[height]</param>
-                <param name="width">$PARAM[width]</param>
-            </include>
-
-            <!-- Tagline Plotline-->
-            <include content="Info_Plot_Main_Plotline" condition="String.IsEmpty(Skin.String(Plotline.Movie))">
-                <param name="infolabel">Tagline</param>
-                <param name="colordiffuse">$PARAM[colordiffuse]</param>
-                <param name="container">$PARAM[container]</param>
-                <param name="listitem">$PARAM[listitem]</param>
-                <param name="use_textbox">$PARAM[use_textbox]</param>
-                <param name="height">$PARAM[height]</param>
-                <param name="width">$PARAM[width]</param>
-            </include>
-
         </control>
 
         <!-- TVShow -->
@@ -1015,30 +1040,8 @@
             <visible>![$PARAM[override]]</visible>
             <visible>String.IsEqual($PARAM[container]$PARAM[listitem].DBType,tvshow)</visible>
             <height>$PARAM[height]</height>
-
-            <!-- No Plotline -->
-            <include content="Info_Plot_TextBox"  condition="Skin.String(Plotline.TVShow,None)">
-                <param name="label">$INFO[$PARAM[container]$PARAM[listitem].Plot]</param>
-                <param name="colordiffuse">$PARAM[colordiffuse]</param>
-                <param name="use_textbox">$PARAM[use_textbox]</param>
-                <param name="height">$PARAM[height]</param>
-                <param name="width">$PARAM[width]</param>
-            </include>
-
-            <!-- Genre Plotline -->
-            <include content="Info_Plot_Main_Plotline" condition="Skin.String(Plotline.TVShow,Genre)">
-                <param name="infolabel">Genre</param>
-                <param name="colordiffuse">$PARAM[colordiffuse]</param>
-                <param name="container">$PARAM[container]</param>
-                <param name="listitem">$PARAM[listitem]</param>
-                <param name="use_textbox">$PARAM[use_textbox]</param>
-                <param name="height">$PARAM[height]</param>
-                <param name="width">$PARAM[width]</param>
-            </include>
-
-            <!-- Tagline Plotline-->
-            <include content="Info_Plot_Main_Plotline" condition="String.IsEmpty(Skin.String(Plotline.TVShow))">
-                <param name="infolabel">Tagline</param>
+            <include content="Info_Plot_Main_Plotline">
+                <param name="dbtype">tvshow</param>
                 <param name="colordiffuse">$PARAM[colordiffuse]</param>
                 <param name="container">$PARAM[container]</param>
                 <param name="listitem">$PARAM[listitem]</param>

--- a/1080i/Includes_Labels.xml
+++ b/1080i/Includes_Labels.xml
@@ -2,17 +2,15 @@
 <includes>
 
     <variable name="Label_Setting_Plotline_Movies">
-        <value condition="Skin.String(Plotline.Movies,Genre)">$LOCALIZE[515]</value>
-        <value condition="String.IsEmpty(Skin.String(Plotline.Movies)) + Skin.HasSetting(Plotline.EnableGenre)">$LOCALIZE[515]</value>
-        <value condition="Skin.String(Plotline.Movies,Director)">$LOCALIZE[20339]</value>
-        <value condition="Skin.String(Plotline.Movies,None)">None</value>
+        <value condition="Skin.String(Plotline.Movie,Genre)">$LOCALIZE[515]</value>
+        <value condition="Skin.String(Plotline.Movie,Director)">$LOCALIZE[20339]</value>
+        <value condition="Skin.String(Plotline.Movie,None)">$LOCALIZE[16018]</value>
         <value>$LOCALIZE[202]</value>
     </variable>
 
-    <variable name="Label_Setting_Plotline_TV">
-        <value condition="Skin.String(Plotline.TV,Genre)">$LOCALIZE[515]</value>
-        <value condition="String.IsEmpty(Skin.String(Plotline.TV)) + Skin.HasSetting(Plotline.EnableGenre)">$LOCALIZE[515]</value>
-        <value condition="Skin.String(Plotline.TV,None)">None</value>
+    <variable name="Label_Setting_Plotline_TVShow">
+        <value condition="Skin.String(Plotline.TVShow,Genre)">$LOCALIZE[515]</value>
+        <value condition="Skin.String(Plotline.TVShow,None)">$LOCALIZE[16018]</value>
         <value>$LOCALIZE[202]</value>
     </variable>
 

--- a/1080i/Includes_Labels.xml
+++ b/1080i/Includes_Labels.xml
@@ -1,8 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <includes>
 
-    <variable name="Label_Setting_Plotline">
-        <value condition="Skin.HasSetting(Plotline.EnableGenre)">$LOCALIZE[515]</value>
+    <variable name="Label_Setting_Plotline_Movies">
+        <value condition="Skin.String(Plotline.Movies,Genre)">$LOCALIZE[515]</value>
+        <value condition="String.IsEmpty(Skin.String(Plotline.Movies)) + Skin.HasSetting(Plotline.EnableGenre)">$LOCALIZE[515]</value>
+        <value condition="Skin.String(Plotline.Movies,Director)">$LOCALIZE[20339]</value>
+        <value condition="Skin.String(Plotline.Movies,None)">None</value>
+        <value>$LOCALIZE[202]</value>
+    </variable>
+
+    <variable name="Label_Setting_Plotline_TV">
+        <value condition="Skin.String(Plotline.TV,Genre)">$LOCALIZE[515]</value>
+        <value condition="String.IsEmpty(Skin.String(Plotline.TV)) + Skin.HasSetting(Plotline.EnableGenre)">$LOCALIZE[515]</value>
+        <value condition="Skin.String(Plotline.TV,None)">None</value>
         <value>$LOCALIZE[202]</value>
     </variable>
 
@@ -491,6 +501,14 @@
     </variable>
 
     <variable name="Label_Tagline">
+        <value condition="Skin.String(Plotline.Movies,Director) + String.IsEqual(ListItem.DBType,movie) + !String.IsEmpty(ListItem.Director)">$INFO[ListItem.Director]</value>
+        <value condition="Skin.String(Plotline.Movies,Director) + String.IsEqual(Window(Home).Property(TMDbHelper.ListItem.DBType),movie) + !String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.Director))">$VAR[Label_FromDirector]</value>
+        <value condition="Skin.String(Plotline.Movies,Director) + String.IsEqual(ListItem.DBType,movie)" />
+        <value condition="Skin.String(Plotline.Movies,Director) + String.IsEqual(Window(Home).Property(TMDbHelper.ListItem.DBType),movie)" />
+        <value condition="Skin.String(Plotline.Movies,None) + String.IsEqual(ListItem.DBType,movie)" />
+        <value condition="Skin.String(Plotline.Movies,None) + String.IsEqual(Window(Home).Property(TMDbHelper.ListItem.DBType),movie)" />
+        <value condition="Skin.String(Plotline.TV,None) + String.IsEqual(ListItem.DBType,tvshow)" />
+        <value condition="Skin.String(Plotline.TV,None) + String.IsEqual(Window(Home).Property(TMDbHelper.ListItem.DBType),tvshow)" />
         <value condition="!String.IsEmpty(ListItem.Tagline)">$INFO[ListItem.Tagline]</value>
         <value condition="!String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.Tagline))">$INFO[Window(Home).Property(TMDbHelper.ListItem.Tagline)]</value>
     </variable>

--- a/1080i/Includes_Labels.xml
+++ b/1080i/Includes_Labels.xml
@@ -10,6 +10,7 @@
 
     <variable name="Label_Setting_Plotline_TVShow">
         <value condition="Skin.String(Plotline.TVShow,Genre)">$LOCALIZE[515]</value>
+        <value condition="Skin.String(Plotline.TVShow,Episodes)">$LOCALIZE[20360]</value>
         <value condition="Skin.String(Plotline.TVShow,None)">$LOCALIZE[16018]</value>
         <value>$LOCALIZE[202]</value>
     </variable>

--- a/1080i/Includes_Labels.xml
+++ b/1080i/Includes_Labels.xml
@@ -500,19 +500,6 @@
         <value condition="!String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.Creator.3.Name))">$INFO[Window(Home).Property(TMDbHelper.ListItem.Creator.3.Name)]</value>
     </variable>
 
-    <variable name="Label_Tagline">
-        <value condition="Skin.String(Plotline.Movies,Director) + String.IsEqual(ListItem.DBType,movie) + !String.IsEmpty(ListItem.Director)">$INFO[ListItem.Director]</value>
-        <value condition="Skin.String(Plotline.Movies,Director) + String.IsEqual(Window(Home).Property(TMDbHelper.ListItem.DBType),movie) + !String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.Director))">$VAR[Label_FromDirector]</value>
-        <value condition="Skin.String(Plotline.Movies,Director) + String.IsEqual(ListItem.DBType,movie)" />
-        <value condition="Skin.String(Plotline.Movies,Director) + String.IsEqual(Window(Home).Property(TMDbHelper.ListItem.DBType),movie)" />
-        <value condition="Skin.String(Plotline.Movies,None) + String.IsEqual(ListItem.DBType,movie)" />
-        <value condition="Skin.String(Plotline.Movies,None) + String.IsEqual(Window(Home).Property(TMDbHelper.ListItem.DBType),movie)" />
-        <value condition="Skin.String(Plotline.TV,None) + String.IsEqual(ListItem.DBType,tvshow)" />
-        <value condition="Skin.String(Plotline.TV,None) + String.IsEqual(Window(Home).Property(TMDbHelper.ListItem.DBType),tvshow)" />
-        <value condition="!String.IsEmpty(ListItem.Tagline)">$INFO[ListItem.Tagline]</value>
-        <value condition="!String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.Tagline))">$INFO[Window(Home).Property(TMDbHelper.ListItem.Tagline)]</value>
-    </variable>
-
     <variable name="Label_OSD_CastMember_Appearances">
         <value condition="!String.IsEmpty(Container(6501).ListItem.Property(numitems.tmdb.movies.cast))">$INFO[Container(6501).ListItem.Property(numitems.tmdb.movies.cast),, $LOCALIZE[342]]$INFO[Container(6501).ListItem.Property(numitems.tmdb.tvshows.cast), $LOCALIZE[1397] , $LOCALIZE[20343]]</value>
         <value condition="!String.IsEmpty(Container(6502).ListItem.Property(numitems.tmdb.movies.cast)) + String.IsEqual(Container(6501).ListItem.Label,Container(6502).ListItem.Label)">$INFO[Container(6502).ListItem.Property(numitems.tmdb.movies.cast),, $LOCALIZE[342]]$INFO[Container(6502).ListItem.Property(numitems.tmdb.tvshows.cast), $LOCALIZE[1397] , $LOCALIZE[20343]]</value>

--- a/1080i/Includes_SkinSettings.xml
+++ b/1080i/Includes_SkinSettings.xml
@@ -645,37 +645,42 @@
         <include content="Settings_Label" description="Interface">
             <param name="window">skinsettings</param>
             <param name="baseid">$PARAM[baseid]</param>
-            <param name="id">006</param>
-            <label>$LOCALIZE[19033]</label>
+            <param name="id">010</param>
+            <label>$LOCALIZE[31126]</label>
         </include>
         <include content="Settings_Button" description="Movie plotline">
-            <param name="dialog">false</param>
-            <param name="window">skinsettings</param>
-            <param name="baseid">$PARAM[baseid]</param>
-            <param name="id">010</param>
-            <param name="dialog">false</param>
-            <param name="control">button</param>
-            <label>$LOCALIZE[31606]</label>
-            <label2>$VAR[Label_Setting_Plotline_Movies]</label2>
-            <onclick condition="String.IsEmpty(Skin.String(Plotline.Movies)) + Skin.HasSetting(Plotline.EnableGenre)">Skin.SetString(Plotline.Movies,Director)</onclick>
-            <onclick condition="String.IsEmpty(Skin.String(Plotline.Movies)) + !Skin.HasSetting(Plotline.EnableGenre)">Skin.SetString(Plotline.Movies,Genre)</onclick>
-            <onclick condition="Skin.String(Plotline.Movies,Genre)">Skin.SetString(Plotline.Movies,Director)</onclick>
-            <onclick condition="Skin.String(Plotline.Movies,Director)">Skin.SetString(Plotline.Movies,None)</onclick>
-            <onclick condition="Skin.String(Plotline.Movies,None)">Skin.Reset(Plotline.Movies)</onclick>
-        </include>
-        <include content="Settings_Button" description="TV plotline">
             <param name="dialog">false</param>
             <param name="window">skinsettings</param>
             <param name="baseid">$PARAM[baseid]</param>
             <param name="id">011</param>
             <param name="dialog">false</param>
             <param name="control">button</param>
-            <label>$LOCALIZE[31607]</label>
-            <label2>$VAR[Label_Setting_Plotline_TV]</label2>
-            <onclick condition="String.IsEmpty(Skin.String(Plotline.TV)) + Skin.HasSetting(Plotline.EnableGenre)">Skin.SetString(Plotline.TV,None)</onclick>
-            <onclick condition="String.IsEmpty(Skin.String(Plotline.TV)) + !Skin.HasSetting(Plotline.EnableGenre)">Skin.SetString(Plotline.TV,Genre)</onclick>
-            <onclick condition="Skin.String(Plotline.TV,Genre)">Skin.SetString(Plotline.TV,None)</onclick>
-            <onclick condition="Skin.String(Plotline.TV,None)">Skin.Reset(Plotline.TV)</onclick>
+            <label>$LOCALIZE[342]</label>
+            <label2>$VAR[Label_Setting_Plotline_Movies]</label2>
+            <onclick condition="String.IsEmpty(Skin.String(Plotline.Movie))">Skin.SetString(Plotline.Movie,Genre)</onclick>
+            <onclick condition="Skin.String(Plotline.Movie,Genre)">Skin.SetString(Plotline.Movie,Director)</onclick>
+            <onclick condition="Skin.String(Plotline.Movie,Director)">Skin.SetString(Plotline.Movie,None)</onclick>
+            <onclick condition="Skin.String(Plotline.Movie,None)">Skin.Reset(Plotline.Movie)</onclick>
+        </include>
+        <include content="Settings_Button" description="TV plotline">
+            <param name="dialog">false</param>
+            <param name="window">skinsettings</param>
+            <param name="baseid">$PARAM[baseid]</param>
+            <param name="id">012</param>
+            <param name="dialog">false</param>
+            <param name="control">button</param>
+            <label>$LOCALIZE[20343]</label>
+            <label2>$VAR[Label_Setting_Plotline_TVShow]</label2>
+            <onclick condition="String.IsEmpty(Skin.String(Plotline.TVShow))">Skin.SetString(Plotline.TVShow,Genre)</onclick>
+            <onclick condition="Skin.String(Plotline.TVShow,Genre)">Skin.SetString(Plotline.TVShow,None)</onclick>
+            <onclick condition="Skin.String(Plotline.TVShow,None)">Skin.Reset(Plotline.TVShow)</onclick>
+        </include>
+
+        <include content="Settings_Label" description="Interface">
+            <param name="window">skinsettings</param>
+            <param name="baseid">$PARAM[baseid]</param>
+            <param name="id">006</param>
+            <label>$LOCALIZE[19033]</label>
         </include>
         <include content="Settings_Button" description="Star Rating">
             <param name="dialog">false</param>

--- a/1080i/Includes_SkinSettings.xml
+++ b/1080i/Includes_SkinSettings.xml
@@ -648,16 +648,34 @@
             <param name="id">006</param>
             <label>$LOCALIZE[19033]</label>
         </include>
-        <include content="Settings_Button" description="Genre">
+        <include content="Settings_Button" description="Movie plotline">
             <param name="dialog">false</param>
             <param name="window">skinsettings</param>
             <param name="baseid">$PARAM[baseid]</param>
             <param name="id">010</param>
             <param name="dialog">false</param>
             <param name="control">button</param>
-            <label>$LOCALIZE[31123]</label>
-            <label2>$VAR[Label_Setting_Plotline]</label2>
-            <onclick>Skin.ToggleSetting(Plotline.EnableGenre)</onclick>
+            <label>$LOCALIZE[31606]</label>
+            <label2>$VAR[Label_Setting_Plotline_Movies]</label2>
+            <onclick condition="String.IsEmpty(Skin.String(Plotline.Movies)) + Skin.HasSetting(Plotline.EnableGenre)">Skin.SetString(Plotline.Movies,Director)</onclick>
+            <onclick condition="String.IsEmpty(Skin.String(Plotline.Movies)) + !Skin.HasSetting(Plotline.EnableGenre)">Skin.SetString(Plotline.Movies,Genre)</onclick>
+            <onclick condition="Skin.String(Plotline.Movies,Genre)">Skin.SetString(Plotline.Movies,Director)</onclick>
+            <onclick condition="Skin.String(Plotline.Movies,Director)">Skin.SetString(Plotline.Movies,None)</onclick>
+            <onclick condition="Skin.String(Plotline.Movies,None)">Skin.Reset(Plotline.Movies)</onclick>
+        </include>
+        <include content="Settings_Button" description="TV plotline">
+            <param name="dialog">false</param>
+            <param name="window">skinsettings</param>
+            <param name="baseid">$PARAM[baseid]</param>
+            <param name="id">011</param>
+            <param name="dialog">false</param>
+            <param name="control">button</param>
+            <label>$LOCALIZE[31607]</label>
+            <label2>$VAR[Label_Setting_Plotline_TV]</label2>
+            <onclick condition="String.IsEmpty(Skin.String(Plotline.TV)) + Skin.HasSetting(Plotline.EnableGenre)">Skin.SetString(Plotline.TV,None)</onclick>
+            <onclick condition="String.IsEmpty(Skin.String(Plotline.TV)) + !Skin.HasSetting(Plotline.EnableGenre)">Skin.SetString(Plotline.TV,Genre)</onclick>
+            <onclick condition="Skin.String(Plotline.TV,Genre)">Skin.SetString(Plotline.TV,None)</onclick>
+            <onclick condition="Skin.String(Plotline.TV,None)">Skin.Reset(Plotline.TV)</onclick>
         </include>
         <include content="Settings_Button" description="Star Rating">
             <param name="dialog">false</param>

--- a/1080i/Includes_SkinSettings.xml
+++ b/1080i/Includes_SkinSettings.xml
@@ -672,7 +672,8 @@
             <label>$LOCALIZE[20343]</label>
             <label2>$VAR[Label_Setting_Plotline_TVShow]</label2>
             <onclick condition="String.IsEmpty(Skin.String(Plotline.TVShow))">Skin.SetString(Plotline.TVShow,Genre)</onclick>
-            <onclick condition="Skin.String(Plotline.TVShow,Genre)">Skin.SetString(Plotline.TVShow,None)</onclick>
+            <onclick condition="Skin.String(Plotline.TVShow,Genre)">Skin.SetString(Plotline.TVShow,Episodes)</onclick>
+            <onclick condition="Skin.String(Plotline.TVShow,Episodes)">Skin.SetString(Plotline.TVShow,None)</onclick>
             <onclick condition="Skin.String(Plotline.TVShow,None)">Skin.Reset(Plotline.TVShow)</onclick>
         </include>
 

--- a/1080i/script-skinviewtypes-includes.xml
+++ b/1080i/script-skinviewtypes-includes.xml
@@ -1,50 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <includes>
-
-    <expression name="Exp_View_500">[[!Window.IsVisible(MyMusicNav.xml) + Container.Content(genres) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Window.IsVisible(MyMusicNav.xml) + Container.Content(genres) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [!Window.IsVisible(MyMusicNav.xml) + Container.Content(years) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Window.IsVisible(MyMusicNav.xml) + Container.Content(years) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Container.Content(studios) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Container.Content(directors) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Container.Content(countries) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Container.Content(tags) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Container.Content(roles) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Container.Content(playlists) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Container.Content(artists) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Container.Content(albums) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Container.Content(songs) + [String.IsEmpty(Container.PluginName)]] | [Container.Content(files) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Container.Content(sources) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Container.Content(addons) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Container.Content() + [String.IsEqual(Container.Property(param.info),dir_calendar_library) | String.IsEqual(Container.Property(param.info),dir_calendar_trakt)] + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Container.Content() + !Window.IsVisible(MyGames.xml) + !Window.IsVisible(MyPVRRecordings.xml) + !Window.IsVisible(MyPVRTimers.xml) + !Window.IsVisible(MyPVRSearch.xml) + !String.IsEqual(Container.Property(param.info),watch_providers) + ![String.IsEqual(Container.Property(param.info),dir_calendar_library) | String.IsEqual(Container.Property(param.info),dir_calendar_trakt)] + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName) + !String.IsEqual(Container.PluginName,plugin.video.themoviedb.helper)]]] | [Container.Content() + String.IsEqual(Container.Property(param.info),watch_providers) + [String.IsEqual(Container.PluginName,plugin.video.themoviedb.helper)]]]</expression>
-    <expression name="Exp_View_500_Include">True</expression>
-    <expression name="Exp_View_501">[[Container.Content(images) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Container.Content(videos) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Container.Content(movies) + [String.IsEmpty(Container.PluginName) | String.IsEqual(Container.PluginName,plugin.video.themoviedb.helper)]] | [Container.Content(episodes) + [[String.IsEmpty(Container.PluginName) | String.IsEqual(Container.PluginName,plugin.video.themoviedb.helper)] | [!String.IsEmpty(Container.PluginName)]]] | [Container.Content(musicvideos) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Container.Content(recordings) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Container.Content(games) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Container.Content() + Window.IsVisible(MyGames.xml) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Container.Content() + Window.IsVisible(MyPVRRecordings.xml) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Container.Content() + Window.IsVisible(MyPVRTimers.xml) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Container.Content() + Window.IsVisible(MyPVRSearch.xml) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]]]</expression>
-    <expression name="Exp_View_501_Include">True</expression>
-    <expression name="Exp_View_502">[[Container.Content(sets) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [!String.IsEqual(Container.Property(param.info),episode_groups) + Container.Content(tvshows) + [[String.IsEmpty(Container.PluginName) | String.IsEqual(Container.PluginName,plugin.video.themoviedb.helper)] | [!String.IsEmpty(Container.PluginName)]]] | [String.IsEqual(Container.Property(param.info),episode_groups) + Container.Content(tvshows) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Container.Content(actors) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Container.Content(movies) + [!String.IsEmpty(Container.PluginName) + !String.IsEqual(Container.PluginName,plugin.video.themoviedb.helper)]] | [!String.IsEqual(Container.Property(param.info),episode_group_seasons) + Container.Content(seasons) + [String.IsEqual(Container.PluginName,plugin.video.themoviedb.helper)]]]</expression>
-    <expression name="Exp_View_502_Include">True</expression>
-    <expression name="Exp_View_503">[False]</expression>
-    <expression name="Exp_View_503_Include">False</expression>
-    <expression name="Exp_View_504">[False]</expression>
-    <expression name="Exp_View_504_Include">False</expression>
-    <expression name="Exp_View_505">[False]</expression>
-    <expression name="Exp_View_505_Include">False</expression>
-    <expression name="Exp_View_506">[[Container.Content() + !Window.IsVisible(MyGames.xml) + !Window.IsVisible(MyPVRRecordings.xml) + !Window.IsVisible(MyPVRTimers.xml) + !Window.IsVisible(MyPVRSearch.xml) + !String.IsEqual(Container.Property(param.info),watch_providers) + ![String.IsEqual(Container.Property(param.info),dir_calendar_library) | String.IsEqual(Container.Property(param.info),dir_calendar_trakt)] + [String.IsEqual(Container.PluginName,plugin.video.themoviedb.helper)]]]</expression>
-    <expression name="Exp_View_506_Include">True</expression>
-    <expression name="Exp_View_507">[False]</expression>
-    <expression name="Exp_View_507_Include">False</expression>
-    <expression name="Exp_View_508">[[Container.Content(songs) + [!String.IsEmpty(Container.PluginName)]]]</expression>
-    <expression name="Exp_View_508_Include">True</expression>
-    <expression name="Exp_View_509">[False]</expression>
-    <expression name="Exp_View_509_Include">False</expression>
-    <expression name="Exp_View_549">[False]</expression>
-    <expression name="Exp_View_549_Include">False</expression>
-    <expression name="Exp_View_510">[False]</expression>
-    <expression name="Exp_View_510_Include">False</expression>
-    <expression name="Exp_View_511">[False]</expression>
-    <expression name="Exp_View_511_Include">False</expression>
-    <expression name="Exp_View_512">[False]</expression>
-    <expression name="Exp_View_512_Include">False</expression>
-    <expression name="Exp_View_513">[False]</expression>
-    <expression name="Exp_View_513_Include">False</expression>
-    <expression name="Exp_View_514">[False]</expression>
-    <expression name="Exp_View_514_Include">False</expression>
-    <expression name="Exp_View_520">[False]</expression>
-    <expression name="Exp_View_520_Include">False</expression>
-    <expression name="Exp_View_521">[[!String.IsEqual(Container.Property(param.info),episode_group_seasons) + Container.Content(seasons) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName) + !String.IsEqual(Container.PluginName,plugin.video.themoviedb.helper)]]] | [String.IsEqual(Container.Property(param.info),episode_group_seasons) + Container.Content(seasons) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Container.Content(videoversions) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Container.Content() + String.IsEqual(Container.Property(param.info),watch_providers) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName) + !String.IsEqual(Container.PluginName,plugin.video.themoviedb.helper)]]]]</expression>
-    <expression name="Exp_View_521_Include">True</expression>
-    <expression name="Exp_View_522">[False]</expression>
-    <expression name="Exp_View_522_Include">False</expression>
-    <expression name="Exp_View_523">[False]</expression>
-    <expression name="Exp_View_523_Include">False</expression>
-    <expression name="Exp_View_524">[False]</expression>
-    <expression name="Exp_View_524_Include">False</expression>
-    <expression name="Exp_View_526">[False]</expression>
-    <expression name="Exp_View_526_Include">False</expression>
-    <expression name="Exp_View_528">[False]</expression>
-    <expression name="Exp_View_528_Include">False</expression>
+    <include name="Action_BuildViews">
+        <onload>RunScript(script.skinvariables,action=buildviews)</onload>
+    </include>
 </includes>

--- a/1080i/script-skinviewtypes-includes.xml
+++ b/1080i/script-skinviewtypes-includes.xml
@@ -1,6 +1,50 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <includes>
-    <include name="Action_BuildViews">
-        <onload>RunScript(script.skinvariables,action=buildviews)</onload>
-    </include>
+
+    <expression name="Exp_View_500">[[!Window.IsVisible(MyMusicNav.xml) + Container.Content(genres) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Window.IsVisible(MyMusicNav.xml) + Container.Content(genres) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [!Window.IsVisible(MyMusicNav.xml) + Container.Content(years) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Window.IsVisible(MyMusicNav.xml) + Container.Content(years) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Container.Content(studios) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Container.Content(directors) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Container.Content(countries) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Container.Content(tags) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Container.Content(roles) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Container.Content(playlists) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Container.Content(artists) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Container.Content(albums) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Container.Content(songs) + [String.IsEmpty(Container.PluginName)]] | [Container.Content(files) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Container.Content(sources) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Container.Content(addons) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Container.Content() + [String.IsEqual(Container.Property(param.info),dir_calendar_library) | String.IsEqual(Container.Property(param.info),dir_calendar_trakt)] + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Container.Content() + !Window.IsVisible(MyGames.xml) + !Window.IsVisible(MyPVRRecordings.xml) + !Window.IsVisible(MyPVRTimers.xml) + !Window.IsVisible(MyPVRSearch.xml) + !String.IsEqual(Container.Property(param.info),watch_providers) + ![String.IsEqual(Container.Property(param.info),dir_calendar_library) | String.IsEqual(Container.Property(param.info),dir_calendar_trakt)] + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName) + !String.IsEqual(Container.PluginName,plugin.video.themoviedb.helper)]]] | [Container.Content() + String.IsEqual(Container.Property(param.info),watch_providers) + [String.IsEqual(Container.PluginName,plugin.video.themoviedb.helper)]]]</expression>
+    <expression name="Exp_View_500_Include">True</expression>
+    <expression name="Exp_View_501">[[Container.Content(images) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Container.Content(videos) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Container.Content(movies) + [String.IsEmpty(Container.PluginName) | String.IsEqual(Container.PluginName,plugin.video.themoviedb.helper)]] | [Container.Content(episodes) + [[String.IsEmpty(Container.PluginName) | String.IsEqual(Container.PluginName,plugin.video.themoviedb.helper)] | [!String.IsEmpty(Container.PluginName)]]] | [Container.Content(musicvideos) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Container.Content(recordings) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Container.Content(games) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Container.Content() + Window.IsVisible(MyGames.xml) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Container.Content() + Window.IsVisible(MyPVRRecordings.xml) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Container.Content() + Window.IsVisible(MyPVRTimers.xml) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Container.Content() + Window.IsVisible(MyPVRSearch.xml) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]]]</expression>
+    <expression name="Exp_View_501_Include">True</expression>
+    <expression name="Exp_View_502">[[Container.Content(sets) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [!String.IsEqual(Container.Property(param.info),episode_groups) + Container.Content(tvshows) + [[String.IsEmpty(Container.PluginName) | String.IsEqual(Container.PluginName,plugin.video.themoviedb.helper)] | [!String.IsEmpty(Container.PluginName)]]] | [String.IsEqual(Container.Property(param.info),episode_groups) + Container.Content(tvshows) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Container.Content(actors) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Container.Content(movies) + [!String.IsEmpty(Container.PluginName) + !String.IsEqual(Container.PluginName,plugin.video.themoviedb.helper)]] | [!String.IsEqual(Container.Property(param.info),episode_group_seasons) + Container.Content(seasons) + [String.IsEqual(Container.PluginName,plugin.video.themoviedb.helper)]]]</expression>
+    <expression name="Exp_View_502_Include">True</expression>
+    <expression name="Exp_View_503">[False]</expression>
+    <expression name="Exp_View_503_Include">False</expression>
+    <expression name="Exp_View_504">[False]</expression>
+    <expression name="Exp_View_504_Include">False</expression>
+    <expression name="Exp_View_505">[False]</expression>
+    <expression name="Exp_View_505_Include">False</expression>
+    <expression name="Exp_View_506">[[Container.Content() + !Window.IsVisible(MyGames.xml) + !Window.IsVisible(MyPVRRecordings.xml) + !Window.IsVisible(MyPVRTimers.xml) + !Window.IsVisible(MyPVRSearch.xml) + !String.IsEqual(Container.Property(param.info),watch_providers) + ![String.IsEqual(Container.Property(param.info),dir_calendar_library) | String.IsEqual(Container.Property(param.info),dir_calendar_trakt)] + [String.IsEqual(Container.PluginName,plugin.video.themoviedb.helper)]]]</expression>
+    <expression name="Exp_View_506_Include">True</expression>
+    <expression name="Exp_View_507">[False]</expression>
+    <expression name="Exp_View_507_Include">False</expression>
+    <expression name="Exp_View_508">[[Container.Content(songs) + [!String.IsEmpty(Container.PluginName)]]]</expression>
+    <expression name="Exp_View_508_Include">True</expression>
+    <expression name="Exp_View_509">[False]</expression>
+    <expression name="Exp_View_509_Include">False</expression>
+    <expression name="Exp_View_549">[False]</expression>
+    <expression name="Exp_View_549_Include">False</expression>
+    <expression name="Exp_View_510">[False]</expression>
+    <expression name="Exp_View_510_Include">False</expression>
+    <expression name="Exp_View_511">[False]</expression>
+    <expression name="Exp_View_511_Include">False</expression>
+    <expression name="Exp_View_512">[False]</expression>
+    <expression name="Exp_View_512_Include">False</expression>
+    <expression name="Exp_View_513">[False]</expression>
+    <expression name="Exp_View_513_Include">False</expression>
+    <expression name="Exp_View_514">[False]</expression>
+    <expression name="Exp_View_514_Include">False</expression>
+    <expression name="Exp_View_520">[False]</expression>
+    <expression name="Exp_View_520_Include">False</expression>
+    <expression name="Exp_View_521">[[!String.IsEqual(Container.Property(param.info),episode_group_seasons) + Container.Content(seasons) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName) + !String.IsEqual(Container.PluginName,plugin.video.themoviedb.helper)]]] | [String.IsEqual(Container.Property(param.info),episode_group_seasons) + Container.Content(seasons) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Container.Content(videoversions) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName)]]] | [Container.Content() + String.IsEqual(Container.Property(param.info),watch_providers) + [[String.IsEmpty(Container.PluginName)] | [!String.IsEmpty(Container.PluginName) + !String.IsEqual(Container.PluginName,plugin.video.themoviedb.helper)]]]]</expression>
+    <expression name="Exp_View_521_Include">True</expression>
+    <expression name="Exp_View_522">[False]</expression>
+    <expression name="Exp_View_522_Include">False</expression>
+    <expression name="Exp_View_523">[False]</expression>
+    <expression name="Exp_View_523_Include">False</expression>
+    <expression name="Exp_View_524">[False]</expression>
+    <expression name="Exp_View_524_Include">False</expression>
+    <expression name="Exp_View_526">[False]</expression>
+    <expression name="Exp_View_526_Include">False</expression>
+    <expression name="Exp_View_528">[False]</expression>
+    <expression name="Exp_View_528_Include">False</expression>
 </includes>

--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -613,6 +613,11 @@ msgctxt "#31125"
 msgid "Invert Text Colour"
 msgstr ""
 
+#: /1080i/Includes_SkinSettings.xml
+msgctxt "#31126"
+msgid "Plotline"
+msgstr ""
+
 #: /1080i/Includes_MediaFilter.xml
 msgctxt "#31128"
 msgid "Trending"
@@ -2293,14 +2298,4 @@ msgstr ""
 #: /1080i/Includes_SkinSettings.xml
 msgctxt "#31605"
 msgid "Next aired"
-msgstr ""
-
-#: /1080i/Includes_SkinSettings.xml
-msgctxt "#31606"
-msgid "Movie plotline"
-msgstr ""
-
-#: /1080i/Includes_SkinSettings.xml
-msgctxt "#31607"
-msgid "TV show plotline"
 msgstr ""

--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -2294,3 +2294,13 @@ msgstr ""
 msgctxt "#31605"
 msgid "Next aired"
 msgstr ""
+
+#: /1080i/Includes_SkinSettings.xml
+msgctxt "#31606"
+msgid "Movie plotline"
+msgstr ""
+
+#: /1080i/Includes_SkinSettings.xml
+msgctxt "#31607"
+msgid "TV show plotline"
+msgstr ""


### PR DESCRIPTION
This PR expands the existing plotline metadata setting by allowing separate behaviour for movies and TV shows.

Summary:
- adds separate `Movie plotline` and `TV show plotline` settings
- Movies have the options `Tagline / Genre / Director / None`
- TV shows have the options `Tagline / Genre / None`
- uses a localized `Dir.` prefix for the movie director label
- when `Director` mode is selected and no director metadata is available, the line is suppressed rather than falling back to tagline

Mostly motivated by a desire to see the director when browsing my library. The main goal is to make the plotline display a bit more flexible for movie libraries without changing the default behaviour for existing users, and to give folks the ability to suppress the plotline entirely if they don't want them.

Implementation notes:
- the same behaviour is applied consistently in the main info area, dialog info, and plot box labels
- new strings were added for `Movie plotline`, `TV show plotline`, and `Dir.`

I've been testing this locally for a few days with mixed movie/TV widgets and it's working well for me.

<img width="719" height="483" alt="Screenshot 2026-04-14 at 9 00 18 PM" src="https://github.com/user-attachments/assets/2ffb2976-7ff6-4029-8dc8-1c487043c678" />