### PR TITLE
Update skinvariables-startup.json

### DIFF
--- a/shortcuts/skinvariables-startup.json
+++ b/shortcuts/skinvariables-startup.json
@@ -163,7 +163,7 @@
                 "!PVR.HasRadioChannels"
             ],
             "value": [
-                "SetProperty(InitStatus,Waiting for PVR,1198)",
+                "SetProperty(InitStatus,$LOCALIZE[31249],1198)",
                 "route=run_executebuiltin=special://skin/shortcuts/skinvariables-startup.json&use_rules=True&var_image_simplebackground={var_image_simplebackground}"
             ]
         },


### PR DESCRIPTION
For proper general translation of the start screen.

31249 is the id for "Waiting for PVR" in all language files