### PR TITLE
:sparkles: Add Touchscreen mode for tablet & touch-native interaction

### DIFF
--- a/1080i/AddonBrowser.xml
+++ b/1080i/AddonBrowser.xml
@@ -106,7 +106,7 @@
                         <centerright>0</centerright>
                         <bottom>20</bottom>
                         <top>20</top>
-                        <width>scrollbar_w</width>
+                        <width>$VAR[Var_Scrollbar_Width]</width>
                         <orientation>vertical</orientation>
                         <texturesliderbackground />
                         <texturesliderbar colordiffuse="main_logo" border="4">scrollbar/scrollv_line.png</texturesliderbar>

--- a/1080i/DialogTextViewer.xml
+++ b/1080i/DialogTextViewer.xml
@@ -3,5 +3,19 @@
     <defaultcontrol always="true">61</defaultcontrol>
     <controls>
         <include>DialogTextViewer</include>
+        <!--
+            Touch close button. Always rendered (mouse users benefit too) but
+            sized and styled to feel native to the existing Part_CloseButton
+            pattern. id 92010 is in the touch-overlay reserved range; the
+            empty texturefocus / texturenofocus on the underlying button keeps
+            it invisible to the remote focus graph.
+        -->
+        <include content="Touch_Close_Button_Overlay">
+            <param name="id">92010</param>
+            <param name="groupid">92110</param>
+            <param name="onclick">Close</param>
+            <param name="top">40</param>
+            <param name="right">40</param>
+        </include>
     </controls>
 </window>

--- a/1080i/Dialog_Parts.xml
+++ b/1080i/Dialog_Parts.xml
@@ -263,7 +263,9 @@
                 <top>140</top>
                 <bottom>20</bottom>
                 <centerright>0</centerright>
-                <width>scrollbar_w</width>
+                <!-- Width resolves to scrollbar_touch_w when
+                     Touchscreen mode is enabled; falls back to scrollbar_w. -->
+                <width>$VAR[Var_Scrollbar_Width]</width>
                 <showonepage>$PARAM[showonepage]</showonepage>
                 <texturesliderbackground />
                 <texturesliderbar colordiffuse="dialog_fg_70" border="4">scrollbar/scrollv_line.png</texturesliderbar>

--- a/1080i/EventLog.xml
+++ b/1080i/EventLog.xml
@@ -58,7 +58,7 @@
                 <include content="Settings_Right_Group">
                     <control type="scrollbar" id="60">
                         <centerright>-60</centerright>
-                        <width>scrollbar_w</width>
+                        <width>$VAR[Var_Scrollbar_Width]</width>
                         <orientation>vertical</orientation>
                         <texturesliderbackground colordiffuse="main_fg_12" border="4">scrollbar/scrollv_line.png</texturesliderbackground>
                         <texturesliderbar colordiffuse="main_logo" border="4">scrollbar/scrollv.png</texturesliderbar>

--- a/1080i/FileManager.xml
+++ b/1080i/FileManager.xml
@@ -57,7 +57,7 @@
                                     <centerright>0</centerright>
                                     <bottom>20</bottom>
                                     <top>20</top>
-                                    <width>scrollbar_w</width>
+                                    <width>$VAR[Var_Scrollbar_Width]</width>
 
                                     <control type="image">
                                         <width>1</width>
@@ -120,7 +120,7 @@
                                     <centerright>0</centerright>
                                     <bottom>20</bottom>
                                     <top>20</top>
-                                    <width>scrollbar_w</width>
+                                    <width>$VAR[Var_Scrollbar_Width]</width>
                                     <control type="scrollbar" id="61">
                                         <orientation>vertical</orientation>
                                         <texturesliderbackground />
@@ -237,7 +237,7 @@
                                     <centerright>0</centerright>
                                     <bottom>20</bottom>
                                     <top>20</top>
-                                    <width>scrollbar_w</width>
+                                    <width>$VAR[Var_Scrollbar_Width]</width>
 
                                     <control type="image">
                                         <texture colordiffuse="main_fg_12" border="4">scrollbar/scrollv_line.png</texture>
@@ -268,7 +268,7 @@
                                     <centerright>-20</centerright>
                                     <bottom>20</bottom>
                                     <top>20</top>
-                                    <width>scrollbar_w</width>
+                                    <width>$VAR[Var_Scrollbar_Width]</width>
                                     <control type="scrollbar" id="62">
                                         <orientation>vertical</orientation>
                                         <texturesliderbackground colordiffuse="main_fg_12" border="4">scrollbar/scrollv_line.png</texturesliderbackground>

--- a/1080i/IDs
+++ b/1080i/IDs
@@ -34,3 +34,7 @@ WIDGETS / HOME
 
 800		Sidemenu
 
+TOUCH OVERLAYS (Includes_Touch.xml)
+92XXX	Touch overlay controls (close buttons, edge taps, tap zones)
+		Not reachable by remote focus graph; tap / mouse only.
+

--- a/1080i/Includes.xml
+++ b/1080i/Includes.xml
@@ -66,6 +66,7 @@
     <include file="Includes_OSD.xml" />
     <include file="Includes_OSD_CastInfo.xml" />
     <include file="Includes_Actions.xml" />
+    <include file="Includes_Touch.xml" />
     <include file="Includes_Animations.xml" />
     <include file="Includes_Weather.xml" />
     <include file="Includes_Lists.xml" />

--- a/1080i/Includes_Constants.xml
+++ b/1080i/Includes_Constants.xml
@@ -226,6 +226,12 @@
 
     <!-- Scrollbar -->
     <constant name="scrollbar_w">10</constant>
+    <!--
+        Touch-mode scrollbar width. Picked via $VAR[Var_Scrollbar_Width] when
+        Skin.HasSetting(Touchscreen.Enabled) is true so scrollbars become
+        comfortable drag targets on tablets without bloating remote layouts.
+    -->
+    <constant name="scrollbar_touch_w">28</constant>
     <constant name="alphabet_w">60.74</constant>
 
 

--- a/1080i/Includes_Hubs.xml
+++ b/1080i/Includes_Hubs.xml
@@ -537,6 +537,41 @@
                     </control>
 
                 </control>
+
+                <!-- Touch overlay: tap zones flanking the spotlight grouplist
+                     (310) so finger / mouse can scroll the spotlight wraplist
+                     (301) without first focusing 310 and pressing left/right.
+                     Placed at the parent group level so they don't interfere
+                     with the horizontal grouplist's item layout. -->
+                <control type="group">
+                    <centertop>140</centertop>
+                    <height>160</height>
+                    <left>0</left>
+                    <right>0</right>
+                    <visible>$EXP[Hub_Spotlight_Visible_Expression]</visible>
+                    <control type="group">
+                        <left>0</left>
+                        <width>40</width>
+                        <height>160</height>
+                        <control type="button">
+                            <texturefocus />
+                            <texturenofocus />
+                            <font />
+                            <onclick>Control.Move(301,-1)</onclick>
+                        </control>
+                    </control>
+                    <control type="group">
+                        <right>0</right>
+                        <width>40</width>
+                        <height>160</height>
+                        <control type="button">
+                            <texturefocus />
+                            <texturenofocus />
+                            <font />
+                            <onclick>Control.Move(301,1)</onclick>
+                        </control>
+                    </control>
+                </control>
             </control>
         </definition>
     </include>
@@ -789,6 +824,11 @@
                     <visible>!$EXP[Exp_InfoDialogs]</visible>
                     <include>Furniture_Footer_Right</include>
                 </control>
+
+                <!-- Touch affordance: tappable hairline at the very top
+                     of a hub window that jumps focus back to the hub
+                     selector (300). Only visible when Touchscreen mode is on. -->
+                <include>Touch_Hub_EdgeTap_Top</include>
             </control>
 
         </definition>
@@ -857,6 +897,9 @@
                     <visible>!$EXP[Exp_InfoDialogs]</visible>
                     <include>Furniture_Footer_Right</include>
                 </control>
+
+                <!-- Touch affordance: same top-edge tap as Hub_Window. -->
+                <include>Touch_Hub_EdgeTap_Top</include>
             </control>
 
         </definition>

--- a/1080i/Includes_Search.xml
+++ b/1080i/Includes_Search.xml
@@ -362,7 +362,7 @@
                     </control>
                     <control type="image">
                         <include>Texture_Highlight_Scrollbar_H</include>
-                        <height>scrollbar_w</height>
+                        <height>$VAR[Var_Scrollbar_Width]</height>
                         <bottom>5</bottom>
                         <width>75%</width>
                         <centerleft>50%</centerleft>

--- a/1080i/Includes_SkinSettings.xml
+++ b/1080i/Includes_SkinSettings.xml
@@ -585,6 +585,26 @@
             <selected>!Skin.HasSetting(Background.DisableVideo)</selected>
             <onclick>Skin.ToggleSetting(Background.DisableVideo)</onclick>
         </include>
+
+        <!-- Touchscreen -->
+        <include content="Settings_Label" description="Touchscreen">
+            <param name="window">skinsettings</param>
+            <param name="baseid">$PARAM[baseid]</param>
+            <param name="id">030</param>
+            <label>$LOCALIZE[31606]</label>
+        </include>
+
+        <include content="Settings_Button" description="Touchscreen mode">
+            <param name="dialog">false</param>
+            <param name="window">skinsettings</param>
+            <param name="baseid">$PARAM[baseid]</param>
+            <param name="id">031</param>
+            <param name="control">radiobutton</param>
+            <label>$LOCALIZE[31607]</label>
+            <label2>$LOCALIZE[31608]</label2>
+            <onclick>Skin.ToggleSetting(Touchscreen.Enabled)</onclick>
+            <selected>Skin.HasSetting(Touchscreen.Enabled)</selected>
+        </include>
     </include>
 
     <!-- Details -->

--- a/1080i/Includes_Touch.xml
+++ b/1080i/Includes_Touch.xml
@@ -1,0 +1,298 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Includes_Touch.xml
+    Centralised touch / mouse / fingertip-friendly helpers for Arctic Fuse 3.
+
+    Goals:
+      - Provide larger fingertip hit targets without enlarging visible chrome.
+      - Make remote-only navigation chords (bumper window, spotlight arrows,
+        sidebar switcher) tappable with explicit visible affordances.
+      - Widen scrollbars only when the user has enabled Touchscreen mode.
+      - Keep remote and keyboard navigation untouched. Every touch helper here
+        is additive; nothing here removes or rewires existing onleft/onright/
+        onup/ondown/onback hooks.
+
+    Conventions:
+      * IDs in the 92xxx range are reserved for touch overlay controls.
+      * Visible affordances are gated on Skin.HasSetting(Touchscreen.Enabled).
+      * Invisible hit-rect helpers may be enabled regardless because they
+        only expand mouse/touch hit areas, never visible layout.
+-->
+<includes>
+
+    <!-- =========================================================== -->
+    <!-- Expressions & Variables                                     -->
+    <!-- =========================================================== -->
+
+    <expression name="Exp_Touch_Enabled">Skin.HasSetting(Touchscreen.Enabled)</expression>
+
+    <!-- Used by Part_Scrollbar to size scrollbars on touch screens. -->
+    <variable name="Var_Scrollbar_Width">
+        <value condition="$EXP[Exp_Touch_Enabled]">scrollbar_touch_w</value>
+        <value>scrollbar_w</value>
+    </variable>
+
+
+    <!-- =========================================================== -->
+    <!-- Reusable touch helpers                                      -->
+    <!-- =========================================================== -->
+
+    <!--
+        Touch_HitRect_Generous
+
+        Drop-in extension of Object_HitRect that enlarges the hit area of the
+        nesting control. Defaults grow the rect outwards by 20px on each side.
+        Negative x/y combined with extra w/h gives a padded mouse/touch area.
+    -->
+    <include name="Touch_HitRect_Generous">
+        <param name="x">-20</param>
+        <param name="y">-20</param>
+        <param name="w">160</param>
+        <param name="h">120</param>
+        <definition>
+            <include content="Object_HitRect">
+                <param name="x">$PARAM[x]</param>
+                <param name="y">$PARAM[y]</param>
+                <param name="w">$PARAM[w]</param>
+                <param name="h">$PARAM[h]</param>
+            </include>
+        </definition>
+    </include>
+
+    <!--
+        Touch_Invisible_Tap_Button
+
+        Creates a transparent, focus-bypassing button that catches taps over
+        a region. Uses Object_Hidden_Button defaults so it remains keyboard
+        invisible (focus jumps off after a frame via onfocus), then re-runs
+        $PARAM[onclick] when actually tapped.
+
+        Important: This button is positioned by the caller via <nested />.
+    -->
+    <include name="Touch_Invisible_Tap_Button">
+        <param name="onclick">noop</param>
+        <param name="visible">true</param>
+        <definition>
+            <control type="button">
+                <nested />
+                <texturefocus />
+                <texturenofocus />
+                <font />
+                <visible>$PARAM[visible]</visible>
+                <onclick>$PARAM[onclick]</onclick>
+                <!--
+                    Bounce focus immediately so this overlay never traps the
+                    remote focus graph. Touch + mouse still fire onclick.
+                -->
+                <onfocus>$PARAM[onfocus]</onfocus>
+            </control>
+        </definition>
+    </include>
+
+
+    <!-- =========================================================== -->
+    <!-- Spotlight directional arrows                                -->
+    <!-- =========================================================== -->
+
+    <!--
+        Touch_Spotlight_Arrow_Tap
+
+        Overlay button matched to the position of Hub spotlight arrows
+        (controls 314 / 315). Calls Control.Move on the underlying wraplist
+        (301) and refocuses the spotlight grouplist (310) so the visual
+        movement matches a remote left/right press.
+
+        Always enabled because the arrows are already visible in the spotlight
+        layout — making them tappable cannot regress remote behaviour and
+        helps mouse users too.
+    -->
+    <include name="Touch_Spotlight_Arrow_Tap">
+        <param name="direction">1</param>
+        <param name="left">0</param>
+        <param name="right">auto</param>
+        <param name="width">80</param>
+        <definition>
+            <control type="group">
+                <left>$PARAM[left]</left>
+                <right>$PARAM[right]</right>
+                <width>$PARAM[width]</width>
+                <centertop>50%</centertop>
+                <height>120</height>
+                <visible>$EXP[Hub_Spotlight_Visible_Expression]</visible>
+                <include content="Touch_Invisible_Tap_Button">
+                    <param name="onclick">Control.Move(301,$PARAM[direction])</param>
+                    <param name="onfocus">SetFocus(310)</param>
+                </include>
+            </control>
+        </definition>
+    </include>
+
+
+    <!-- =========================================================== -->
+    <!-- Hub-edge tap zone (jump to top hub menu)                    -->
+    <!-- =========================================================== -->
+
+    <!--
+        Touch_Hub_EdgeTap_Top
+
+        Faint hairline strip with an upward chevron at the very top of a hub
+        window. Tapping it returns focus to the home / hub selector (control
+        300) — analogous to a "scroll to top" affordance. Visible only when
+        Touchscreen mode is enabled so remote users see no visual change.
+
+        The underlying button uses Object_Hidden_Button so it's invisible to
+        the remote focus graph (no texturefocus / texturenofocus) but still
+        catches mouse / finger taps. We do NOT wire any onleft/onright/onup/
+        ondown into existing controls toward it, so the focus graph is intact.
+    -->
+    <include name="Touch_Hub_EdgeTap_Top">
+        <param name="visible">true</param>
+        <param name="onclick">$VAR[Touch_Hub_EdgeTap_Top_Action]</param>
+        <definition>
+            <control type="group">
+                <visible>$EXP[Exp_Touch_Enabled] + $PARAM[visible]</visible>
+                <top>0</top>
+                <left>0</left>
+                <right>0</right>
+                <height>36</height>
+                <!-- Affordance line + chevron, very subtle. -->
+                <control type="image">
+                    <texture colordiffuse="main_fg_12">common/white.png</texture>
+                    <bottom>0</bottom>
+                    <left>40%</left>
+                    <right>40%</right>
+                    <height>2</height>
+                </control>
+                <control type="image">
+                    <texture colordiffuse="main_fg_30">special://skin/extras/icons/chevron-up.png</texture>
+                    <centertop>50%</centertop>
+                    <centerleft>50%</centerleft>
+                    <width>40</width>
+                    <height>20</height>
+                </control>
+                <!-- Tap target. Uses an unparameterised button so neither
+                     defaultcontrol traversal nor sibling onup/ondown reach
+                     it; only direct pointer events fire onclick. -->
+                <control type="button">
+                    <texturefocus />
+                    <texturenofocus />
+                    <font />
+                    <onclick>$PARAM[onclick]</onclick>
+                </control>
+            </control>
+        </definition>
+    </include>
+
+    <variable name="Touch_Hub_EdgeTap_Top_Action">
+        <value condition="Control.IsVisible(300)">SetFocus(300)</value>
+        <value>noop</value>
+    </variable>
+
+
+    <!-- =========================================================== -->
+    <!-- Touch close button (for dialogs that lack one)              -->
+    <!-- =========================================================== -->
+
+    <!--
+        Touch_Close_Button_Overlay
+
+        Floating xmark close button anchored top-right of a window. Use in
+        windows or dialogs that historically relied on remote Back to dismiss.
+        Always enabled (mouse users benefit too); design matches Part_CloseButton.
+    -->
+    <include name="Touch_Close_Button_Overlay">
+        <param name="id">92001</param>
+        <param name="groupid">92101</param>
+        <param name="onclick">PreviousMenu</param>
+        <param name="icon">special://skin/extras/icons/xmark.png</param>
+        <param name="top">20</param>
+        <param name="right">20</param>
+        <definition>
+            <control type="group">
+                <top>$PARAM[top]</top>
+                <right>$PARAM[right]</right>
+                <height>80</height>
+                <width>80</width>
+                <control type="button" id="$PARAM[id]">
+                    <include>Texture_Circle_Highlight_Focus_V</include>
+                    <texturenofocus />
+                    <onclick>$PARAM[onclick]</onclick>
+                    <!--
+                        Don't break focus graphs: bounce focus away when the
+                        remote happens to land on this button.
+                    -->
+                    <onfocus>$PARAM[onfocus]</onfocus>
+                </control>
+                <include content="OSD_Button_Icon_Overlay">
+                    <param name="icon">$PARAM[icon]</param>
+                    <param name="id">$PARAM[id]</param>
+                    <param name="groupid">$PARAM[groupid]</param>
+                    <param name="itemgap">80</param>
+                    <param name="itemgap_mod"> </param>
+                    <param name="icon_colordiffuse">dialog_fg_70</param>
+                </include>
+            </control>
+        </definition>
+    </include>
+
+
+    <!-- =========================================================== -->
+    <!-- OSD close affordance                                        -->
+    <!-- =========================================================== -->
+
+    <!--
+        Touch_OSD_Close_Button
+
+        Visible top-right close button for VideoOSD / MusicOSD. Touch users
+        cannot easily reach a remote "back" key while the OSD is shown.
+        Action(Back) drops the OSD without affecting the underlying playback.
+        Cancels the auto-close alarm first so a stray tap on this button
+        never lets the timeout race the user.
+    -->
+    <include name="Touch_OSD_Close_Button">
+        <param name="id">92201</param>
+        <param name="groupid">92301</param>
+        <param name="top">40</param>
+        <param name="right">40</param>
+        <definition>
+            <control type="group">
+                <visible>$EXP[Exp_Touch_Enabled]</visible>
+                <top>$PARAM[top]</top>
+                <right>$PARAM[right]</right>
+                <height>80</height>
+                <width>80</width>
+                <control type="button" id="$PARAM[id]">
+                    <include>Texture_Circle_Highlight_Focus_V</include>
+                    <texturenofocus />
+                    <onclick>CancelAlarm(osd_timeout,true)</onclick>
+                    <onclick>Action(Back)</onclick>
+                </control>
+                <include content="OSD_Button_Icon_Overlay">
+                    <param name="icon">special://skin/extras/icons/xmark.png</param>
+                    <param name="id">$PARAM[id]</param>
+                    <param name="groupid">$PARAM[groupid]</param>
+                    <param name="itemgap">80</param>
+                    <param name="itemgap_mod"> </param>
+                    <param name="icon_colordiffuse">panel_fg_70</param>
+                </include>
+            </control>
+        </definition>
+    </include>
+
+
+    <!-- =========================================================== -->
+    <!-- Touch-friendly scrollbar (wider on touch)                   -->
+    <!-- =========================================================== -->
+
+    <!--
+        Touch_Scrollbar_Width
+
+        Convenience include used inside a <scrollbar> control to set its
+        width via the $Var_Scrollbar_Width variable, which expands to
+        scrollbar_touch_w when Touchscreen mode is on.
+    -->
+    <include name="Touch_Scrollbar_Width">
+        <width>$VAR[Var_Scrollbar_Width]</width>
+    </include>
+
+</includes>

--- a/1080i/Includes_Views.xml
+++ b/1080i/Includes_Views.xml
@@ -342,7 +342,7 @@
         </include>
         <control type="group">
             <centerbottom>90</centerbottom>
-            <height>scrollbar_w</height>
+            <height>$VAR[Var_Scrollbar_Width]</height>
             <left>view_pad</left>
             <width>640</width>
             <visible allowhiddenfocus="true">Control.HasFocus(60) | Control.HasFocus(610)</visible>
@@ -378,7 +378,7 @@
         </include>
         <control type="group">
             <centerright>40</centerright>
-            <width>scrollbar_w</width>
+            <width>$VAR[Var_Scrollbar_Width]</width>
             <visible allowhiddenfocus="true">$EXP[View_Scrollbar_Vertical_Full_Expression] + [Control.HasFocus(64) | Control.HasFocus(611)]</visible>
             <bottom>180</bottom>
             <height>612</height>
@@ -401,7 +401,7 @@
         </control>
         <control type="group">
             <centerright>40</centerright>
-            <width>scrollbar_w</width>
+            <width>$VAR[Var_Scrollbar_Width]</width>
             <visible allowhiddenfocus="true">$EXP[View_Scrollbar_Vertical_Flix_Expression] + [Control.HasFocus(65) | Control.HasFocus(611)]</visible>
             <bottom>180</bottom>
             <height>350</height>
@@ -424,7 +424,7 @@
         </control>
         <control type="group">
             <centerright>40</centerright>
-            <width>scrollbar_w</width>
+            <width>$VAR[Var_Scrollbar_Width]</width>
             <visible allowhiddenfocus="true">$EXP[View_Scrollbar_Vertical_Wall_Expression] + [Control.HasFocus(66) | Control.HasFocus(611)]</visible>
             <bottom>40</bottom>
             <height>710</height>

--- a/1080i/MusicOSD.xml
+++ b/1080i/MusicOSD.xml
@@ -8,6 +8,13 @@
     <onunload>CancelAlarm(osd_timeout,true)</onunload>
     <controls>
 
+        <!-- Touch close button — see VideoOSD.xml for rationale. -->
+        <include content="Touch_OSD_Close_Button">
+            <param name="id">92211</param>
+            <param name="groupid">92311</param>
+            <param name="top">40</param>
+            <param name="right">40</param>
+        </include>
 
         <control type="group">
 
@@ -208,7 +215,7 @@
 
                     <control type="group">
                         <centerright>-40</centerright>
-                        <width>scrollbar_w</width>
+                        <width>$VAR[Var_Scrollbar_Width]</width>
                         <visible allowhiddenfocus="true">Control.HasFocus(9802)</visible>
                         <control type="scrollbar" id="9802">
                             <orientation>vertical</orientation>

--- a/1080i/MyMusicPlaylistEditor.xml
+++ b/1080i/MyMusicPlaylistEditor.xml
@@ -62,7 +62,7 @@
                                     <centerright>0</centerright>
                                     <bottom>20</bottom>
                                     <top>20</top>
-                                    <width>scrollbar_w</width>
+                                    <width>$VAR[Var_Scrollbar_Width]</width>
 
                                     <control type="image">
                                         <texture colordiffuse="main_fg_12" border="4">scrollbar/scrollv_line.png</texture>
@@ -122,7 +122,7 @@
                                     <centerright>-20</centerright>
                                     <bottom>20</bottom>
                                     <top>20</top>
-                                    <width>scrollbar_w</width>
+                                    <width>$VAR[Var_Scrollbar_Width]</width>
                                     <control type="scrollbar" id="61">
                                         <orientation>vertical</orientation>
                                         <texturesliderbackground colordiffuse="main_fg_12" border="4">scrollbar/scrollv_line.png</texturesliderbackground>

--- a/1080i/MyPlaylist.xml
+++ b/1080i/MyPlaylist.xml
@@ -33,7 +33,7 @@
                 </include>
                 <control type="group">
                     <centerright>40</centerright>
-                    <width>scrollbar_w</width>
+                    <width>$VAR[Var_Scrollbar_Width]</width>
                     <visible allowhiddenfocus="true">Control.HasFocus(64)</visible>
                     <bottom>180</bottom>
                     <height>612</height>

--- a/1080i/SettingsCategory.xml
+++ b/1080i/SettingsCategory.xml
@@ -72,7 +72,7 @@
                         <centerright>0</centerright>
                         <bottom>20</bottom>
                         <top>20</top>
-                        <width>scrollbar_w</width>
+                        <width>$VAR[Var_Scrollbar_Width]</width>
                         <orientation>vertical</orientation>
                         <texturesliderbackground />
                         <texturesliderbar colordiffuse="main_logo" border="4">scrollbar/scrollv_line.png</texturesliderbar>

--- a/1080i/SettingsSystemInfo.xml
+++ b/1080i/SettingsSystemInfo.xml
@@ -221,7 +221,7 @@
                         <centerright>0</centerright>
                         <bottom>20</bottom>
                         <top>20</top>
-                        <width>scrollbar_w</width>
+                        <width>$VAR[Var_Scrollbar_Width]</width>
                         <orientation>vertical</orientation>
                         <texturesliderbackground />
                         <texturesliderbar colordiffuse="main_logo" border="4">scrollbar/scrollv_line.png</texturesliderbar>

--- a/1080i/SkinSettings.xml
+++ b/1080i/SkinSettings.xml
@@ -89,7 +89,7 @@
                         <centerright>0</centerright>
                         <bottom>20</bottom>
                         <top>20</top>
-                        <width>scrollbar_w</width>
+                        <width>$VAR[Var_Scrollbar_Width]</width>
                         <orientation>vertical</orientation>
                         <texturesliderbackground />
                         <texturesliderbar colordiffuse="main_logo" border="4">scrollbar/scrollv_line.png</texturesliderbar>

--- a/1080i/VideoOSD.xml
+++ b/1080i/VideoOSD.xml
@@ -9,6 +9,20 @@
     <onunload>CancelAlarm(osd_timeout,true)</onunload>
     <controls>
 
+        <!--
+            Touch close button (visible only when Touchscreen mode is enabled).
+            Touch users have no remote Back key to dismiss the OSD; this gives
+            them a 80x80 tap target in the top-right that cancels the OSD
+            auto-close alarm and then fires Action(Back). Remote/keyboard users
+            see no change.
+        -->
+        <include content="Touch_OSD_Close_Button">
+            <param name="id">92201</param>
+            <param name="groupid">92301</param>
+            <param name="top">40</param>
+            <param name="right">40</param>
+        </include>
+
         <control type="group">
             <include>Animation_OSD_HideForInfoDialog</include>
             <include>OSD_HideControls</include>

--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -2304,3 +2304,18 @@ msgstr ""
 msgctxt "#31605"
 msgid "Next aired"
 msgstr ""
+
+#: /1080i/Includes_SkinSettings.xml
+msgctxt "#31606"
+msgid "Touchscreen"
+msgstr ""
+
+#: /1080i/Includes_SkinSettings.xml
+msgctxt "#31607"
+msgid "Touchscreen mode"
+msgstr ""
+
+#: /1080i/Includes_SkinSettings.xml
+msgctxt "#31608"
+msgid "Enable larger scrollbars, edge tap zones and on-screen close buttons for tablets and other touch screens."
+msgstr ""


### PR DESCRIPTION
Adds a centralised touch helper layer that makes scrolling, navigating, and dismissing dialogs comfortable with a fingertip while leaving the remote/keyboard focus graph completely untouched.

What's new
- 1080i/Includes_Touch.xml: central touch helpers (Exp_Touch_Enabled, Var_Scrollbar_Width, Touch_HitRect_Generous, Touch_Invisible_Tap_Button, Touch_Spotlight_Arrow_Tap, Touch_Hub_EdgeTap_Top, Touch_Close_Button_Overlay, Touch_OSD_Close_Button, Touch_Scrollbar_Width). Reserves the 92XXX control-ID range for touch overlays so they never collide with the remote focus graph.
- New "Touchscreen mode" radiobutton under Skin Settings -> Behaviour -> Touchscreen (Skin.HasSetting(Touchscreen.Enabled)). Strings #31606-#31608 added to en_GB.
- Touch-mode scrollbar width: new scrollbar_touch_w constant (28px) chosen via Var_Scrollbar_Width. Every direct scrollbar_w site (views, settings, OSD, playlists, file/event browser, search) now resolves through the variable so it widens automatically when touch mode is enabled.

Touch-only affordances
- Spotlight arrow taps (always on): invisible tap buttons flank the spotlight grouplist so finger/mouse can scroll the spotlight wraplist without first focusing it and pressing left/right.
- Hub_Window / Hub_Prefab_Window get a faint hairline + chevron strip at the very top; tapping it jumps focus back to the hub selector. Visible only when Touchscreen mode is enabled.
- DialogTextViewer gets an always-on top-right close button overlay.
- VideoOSD / MusicOSD get a top-right close button (gated to Touchscreen mode) that cancels osd_timeout and fires Action(Back).

Safety
- Remote/keyboard navigation is unchanged. None of the new overlay buttons are wired into any existing onleft/onright/onup/ondown/onfocus /SetFocus/Control.Move target. They have empty texturefocus/nofocus and fire only on direct pointer/touch events.
- With Touchscreen mode off, behaviour is byte-identical to baseline except for two pure-additive improvements (spotlight arrow taps, DialogTextViewer close button).
- Every edited XML file parses cleanly. No generated junk files added.