### PR TITLE
Fix for OzWeather > 2.1.6

### DIFF
--- a/1080i/Dialog_DialogWeather.xml
+++ b/1080i/Dialog_DialogWeather.xml
@@ -724,32 +724,32 @@
                 <include content="Part_Box">
                     <control type="image">
                         <aspectratio scalediffuse="false">scale</aspectratio>
-                        <texture background="true" diffuse="diffuse/square_w600_h600.png">special://profile/addon_data/weather.ozweather/radarbackgrounds/$INFO[Window(weather).Property(Radar)]/legend.png</texture>
+                        <texture background="true" diffuse="diffuse/square_w600_h600.png">special://temp/ozweather/backgrounds/$INFO[Window(weather).Property(Radar)]/legend.png</texture>
                     </control>
                     <control type="image">
                         <aspectratio scalediffuse="false">scale</aspectratio>
-                        <texture background="true" diffuse="diffuse/square_w600_h600.png">special://profile/addon_data/weather.ozweather/radarbackgrounds/$INFO[Window(weather).Property(Radar)]/background.png</texture>
+                        <texture background="true" diffuse="diffuse/square_w600_h600.png">special://temp/ozweather/backgrounds/$INFO[Window(weather).Property(Radar)]/background.png</texture>
                     </control>
                     <control type="image">
                         <aspectratio scalediffuse="false">scale</aspectratio>
-                        <texture background="true" diffuse="diffuse/square_w600_h600.png">special://profile/addon_data/weather.ozweather/radarbackgrounds/$INFO[Window(weather).Property(Radar)]/topography.png</texture>
+                        <texture background="true" diffuse="diffuse/square_w600_h600.png">special://temp/ozweather/backgrounds/$INFO[Window(weather).Property(Radar)]/topography.png</texture>
                     </control>
                     <control type="image">
                         <aspectratio scalediffuse="false">scale</aspectratio>
-                        <texture background="true" diffuse="diffuse/square_w600_h600.png">special://profile/addon_data/weather.ozweather/radarbackgrounds/$INFO[Window(weather).Property(Radar)]/catchments.png</texture>
+                        <texture background="true" diffuse="diffuse/square_w600_h600.png">special://temp/ozweather/backgrounds/$INFO[Window(weather).Property(Radar)]/catchments.png</texture>
                     </control>
                     <control type="image">
                         <aspectratio scalediffuse="false">scale</aspectratio>
-                        <texture background="true" diffuse="diffuse/square_w600_h600.png">special://profile/addon_data/weather.ozweather/radarbackgrounds/$INFO[Window(weather).Property(Radar)]/range.png</texture>
+                        <texture background="true" diffuse="diffuse/square_w600_h600.png">special://temp/ozweather/backgrounds/$INFO[Window(weather).Property(Radar)]/range.png</texture>
                     </control>
                     <control type="image">
                         <aspectratio scalediffuse="false">scale</aspectratio>
-                        <texture background="true" diffuse="diffuse/square_w600_h600.png">special://profile/addon_data/weather.ozweather/radarbackgrounds/$INFO[Window(weather).Property(Radar)]/locations.png</texture>
+                        <texture background="true" diffuse="diffuse/square_w600_h600.png">special://temp/ozweather/backgrounds/$INFO[Window(weather).Property(Radar)]/locations.png</texture>
                     </control>
                     <control type="multiimage">
                         <description>Radar Loop</description>
                         <aspectratio scalediffuse="false">scale</aspectratio>
-                        <imagepath diffuse="diffuse/square_w600_h600.png">special://profile/addon_data/weather.ozweather/currentloop/$INFO[Window(weather).Property(Radar)]/</imagepath>
+                        <imagepath diffuse="diffuse/square_w600_h600.png">special://temp/ozweather/loop/$INFO[Window(weather).Property(Radar)]/</imagepath>
                         <timeperimage>300</timeperimage>
                         <pauseatend>800</pauseatend>
                         <fadetime>0</fadetime>


### PR DESCRIPTION
OzWeather changed its radar file paths in version 2.1.6. The backgrounds and loop images moved from:

special://profile/addon_data/weather.ozweather/radarbackgrounds/<id>/
special://profile/addon_data/weather.ozweather/currentloop/<id>/

to:

special://temp/ozweather/backgrounds/<id>/
special://temp/ozweather/loop/<id>/

The existing paths in DialogWeather_Radar_OzWeather cause Kodi to log texture cache errors and display a blank radar panel for anyone running OzWeather 2.1.6 or later (the current release is 2.1.8).

(Tested with OzWeather 2.1.8 on Kodi 22.0-ALPHA2.)