### PR TITLE
i18n: Add Polish translation and fix "Label" context

### DIFF
--- a/1080i/Dialog_DialogShortcuts.xml
+++ b/1080i/Dialog_DialogShortcuts.xml
@@ -483,7 +483,7 @@
         <include content="Settings_Button" description="Label">
             <param name="dialog">false</param>
             <param name="id">8001</param>
-            <label>$LOCALIZE[21899]</label>
+            <label>$LOCALIZE[31273]</label>
             <label2>$INFO[Skin.String(HomeSwitcher.$PARAM[window].Name)]</label2>
             <onclick>Skin.SetString(HomeSwitcher.$PARAM[window].Name)</onclick>
         </include>
@@ -515,7 +515,7 @@
         <include content="Settings_Button" description="Label">
             <param name="dialog">false</param>
             <param name="id">8001</param>
-            <label>$LOCALIZE[21899]</label>
+            <label>$LOCALIZE[31273]</label>
             <label2>$INFO[Skin.String(HomeSwitcher.$PARAM[window].Spotlight.Label)]</label2>
             <onclick>Skin.SetString(HomeSwitcher.$PARAM[window].Spotlight.Label)</onclick>
         </include>
@@ -926,7 +926,7 @@
             <param name="id">92$PARAM[item]3</param>
             <param name="control">button</param>
             <param name="dialog">true</param>
-            <label> - $LOCALIZE[21899]</label>
+            <label> - $LOCALIZE[31273]</label>
             <label2>$INFO[Skin.String(OptionsTiles.0$PARAM[item].Label)]</label2>
             <visible>$PARAM[visible]</visible>
             <onclick>Skin.SetString(OptionsTiles.0$PARAM[item].Label)</onclick>

--- a/1080i/Includes_Expressions.xml
+++ b/1080i/Includes_Expressions.xml
@@ -76,7 +76,7 @@
 
     <expression name="Exp_InfoDialogs_WidgetsGroup_HasFocus">[ControlGroup(5000).HasFocus()]</expression>
 
-    <expression name="Exp_IsAlphabetStrip">[!Skin.HasSetting(Navigation.DisableAlphabetJump) + !Window.IsVisible(MyPlaylist.xml) + [String.IsEqual(Container.SortMethod,$LOCALIZE[20376]) | String.IsEqual(Container.SortMethod,$LOCALIZE[556]) | String.IsEqual(Container.SortMethod,$LOCALIZE[551]) | String.IsEqual(Container.SortMethod,$LOCALIZE[21899]) | String.IsEqual(Container.SortMethod,$LOCALIZE[31273]) | String.IsEqual(Container.SortMethod,$LOCALIZE[557]) | String.IsEqual(Container.SortMethod,$LOCALIZE[558]) | String.IsEqual(Container.SortMethod,$LOCALIZE[578])]]</expression>
+    <expression name="Exp_IsAlphabetStrip">[!Skin.HasSetting(Navigation.DisableAlphabetJump) + !Window.IsVisible(MyPlaylist.xml) + [String.IsEqual(Container.SortMethod,$LOCALIZE[20376]) | String.IsEqual(Container.SortMethod,$LOCALIZE[556]) | String.IsEqual(Container.SortMethod,$LOCALIZE[551]) | String.IsEqual(Container.SortMethod,$LOCALIZE[21899]) | String.IsEqual(Container.SortMethod,$LOCALIZE[557]) | String.IsEqual(Container.SortMethod,$LOCALIZE[558]) | String.IsEqual(Container.SortMethod,$LOCALIZE[578])]]</expression>
 
     <expression name="Exp_PVRGuide_NoFocus">[Control.HasFocus(28) | Control.HasFocus(11)]</expression>
 

--- a/1080i/Includes_Expressions.xml
+++ b/1080i/Includes_Expressions.xml
@@ -76,7 +76,7 @@
 
     <expression name="Exp_InfoDialogs_WidgetsGroup_HasFocus">[ControlGroup(5000).HasFocus()]</expression>
 
-    <expression name="Exp_IsAlphabetStrip">[!Skin.HasSetting(Navigation.DisableAlphabetJump) + !Window.IsVisible(MyPlaylist.xml) + [String.IsEqual(Container.SortMethod,$LOCALIZE[20376]) | String.IsEqual(Container.SortMethod,$LOCALIZE[556]) | String.IsEqual(Container.SortMethod,$LOCALIZE[551]) | String.IsEqual(Container.SortMethod,$LOCALIZE[21899]) | String.IsEqual(Container.SortMethod,$LOCALIZE[557]) | String.IsEqual(Container.SortMethod,$LOCALIZE[558]) | String.IsEqual(Container.SortMethod,$LOCALIZE[578])]]</expression>
+    <expression name="Exp_IsAlphabetStrip">[!Skin.HasSetting(Navigation.DisableAlphabetJump) + !Window.IsVisible(MyPlaylist.xml) + [String.IsEqual(Container.SortMethod,$LOCALIZE[20376]) | String.IsEqual(Container.SortMethod,$LOCALIZE[556]) | String.IsEqual(Container.SortMethod,$LOCALIZE[551]) | String.IsEqual(Container.SortMethod,$LOCALIZE[21899]) | String.IsEqual(Container.SortMethod,$LOCALIZE[31273]) | String.IsEqual(Container.SortMethod,$LOCALIZE[557]) | String.IsEqual(Container.SortMethod,$LOCALIZE[558]) | String.IsEqual(Container.SortMethod,$LOCALIZE[578])]]</expression>
 
     <expression name="Exp_PVRGuide_NoFocus">[Control.HasFocus(28) | Control.HasFocus(11)]</expression>
 

--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -1119,6 +1119,10 @@ msgctxt "#31272"
 msgid "Searching"
 msgstr ""
 
+msgctxt "#31273"
+msgid "Label"
+msgstr ""
+
 #: /1080i/Includes_Items.xml
 msgctxt "#31274"
 msgid "Icon"

--- a/language/resource.language.pl_pl/strings.po
+++ b/language/resource.language.pl_pl/strings.po
@@ -7,2304 +7,2304 @@ msgstr ""
 "Project-Id-Version: \n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: \n"
-"Last-Translator: \n"
+"Last-Translator: ch1re\n"
 "Language-Team: \n"
-"Language: en\n"
+"Language: pl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.4.1\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Poedit 3.9\n"
 
 msgctxt "#31000"
 msgid "Live TV / PVR"
-msgstr ""
+msgstr "TV na żywo / PVR"
 
 #: /1080i/Includes_MediaFilter.xml
 msgctxt "#31001"
 msgid "In-Progress Episodes"
-msgstr ""
+msgstr "Odcinki w trakcie"
 
 #: /1080i/Includes_Views_Combined.xml
 msgctxt "#31002"
 msgid "Combined Square"
-msgstr ""
+msgstr "Łączony: Kwadratowy"
 
 #: /1080i/Includes_Views_Combined.xml
 msgctxt "#31003"
 msgid "Combined Landscape"
-msgstr ""
+msgstr "Łączony: Poziomy"
 
 #: /1080i/Includes_Views_Combined.xml
 msgctxt "#31004"
 msgid "Combined Poster"
-msgstr ""
+msgstr "Łączony: Plakaty"
 
 #: /1080i/Includes_Views_Combined.xml
 msgctxt "#31005"
 msgid "Combined Circle"
-msgstr ""
+msgstr "Łączony: Okrągły"
 
 #: /1080i/Includes_Views_Combined.xml
 msgctxt "#31006"
 msgid "Combined Board"
-msgstr ""
+msgstr "Łączony: Tablica"
 
 #: /1080i/Dialog_DialogSelect.xml
 msgctxt "#31007"
 msgid "Row"
-msgstr ""
+msgstr "Karuzela"
 
 #: /1080i/Dialog_DialogSelect.xml
 msgctxt "#31008"
 msgid "Wall"
-msgstr ""
+msgstr "Siatka"
 
 #: /1080i/Includes_Shortcuts_Window.xml
 msgctxt "#31009"
 msgid "Widget Customisation"
-msgstr ""
+msgstr "Konfiguracja widżetów"
 
 #: /1080i/Includes_Hubs.xml
 msgctxt "#31010"
 msgid "Program"
-msgstr ""
+msgstr "Program"
 
 #: /1080i/Includes_Hubs.xml
 msgctxt "#31011"
 msgid "Picture"
-msgstr ""
+msgstr "Obraz"
 
 #: /1080i/Includes_Hubs.xml
 msgctxt "#31012"
 msgid "Recent"
-msgstr ""
+msgstr "Ostatnie"
 
 #: /1080i/Includes_Views_PVR.xml
 msgctxt "#31013"
 msgid "List Standard"
-msgstr ""
+msgstr "Lista: Prosta"
 
 #: /1080i/Includes_Views_PVR.xml
 msgctxt "#31014"
 msgid "List Info"
-msgstr ""
+msgstr "Lista: Z zarysem"
 
 msgctxt "#31015"
 msgid "Order"
-msgstr ""
+msgstr "Kolejność"
 
 msgctxt "#31016"
 msgid "Sort by"
-msgstr ""
+msgstr "Sortowanie"
 
 #: /1080i/Includes_Views_PVR.xml
 msgctxt "#31017"
 msgid "List Details"
-msgstr ""
+msgstr "Lista: Szczegółowa"
 
 msgctxt "#31018"
 msgid "Recommendations"
-msgstr ""
+msgstr "Polecane"
 
 #: /1080i/Includes_Views_PVR.xml
 msgctxt "#31019"
 msgid "List Planner"
-msgstr ""
+msgstr "Lista: Ramówka"
 
 #: /1080i/Includes_Views_PVR.xml
 msgctxt "#31020"
 msgid "List Outline"
-msgstr ""
+msgstr "Lista: Ramówka z zarysem"
 
 #: /1080i/Includes_Views_Combined.xml
 msgctxt "#31021"
 msgid "Combined Expanded"
-msgstr ""
+msgstr "Łączony: Rozszerzony"
 
 msgctxt "#31022"
 msgid "items"
-msgstr ""
+msgstr "pozycji"
 
 msgctxt "#31023"
 msgid "Loading"
-msgstr ""
+msgstr "Ładowanie"
 
 msgctxt "#31024"
 msgid "Critics Consensus"
-msgstr ""
+msgstr "Konsensus krytyków"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31025"
 msgid "Item"
-msgstr ""
+msgstr "Element"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31026"
 msgid "Hub"
-msgstr ""
+msgstr "Hub"
 
 #: /1080i/Includes_SkinSettings.xml
 msgctxt "#31027"
 msgid "Focus widgets on startup"
-msgstr ""
+msgstr "Fokusuj widżety po starcie"
 
 msgctxt "#31028"
 msgid "Outline"
-msgstr ""
+msgstr "Zarys"
 
 #: /1080i/Includes_Items.xml
 msgctxt "#31029"
 msgid "Images"
-msgstr ""
+msgstr "Obrazy"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31030"
 msgid "Critics"
-msgstr ""
+msgstr "Krytycy"
 
 #: /1080i/Includes_SkinSettings.xml
 msgctxt "#31031"
 msgid "HDR type"
-msgstr ""
+msgstr "Typ HDR"
 
 #: /1080i/DialogPVRChannelManager.xml
 msgctxt "#31032"
 msgid "Apply"
-msgstr ""
+msgstr "Zastosuj"
 
 msgctxt "#31033"
 msgid "People"
-msgstr ""
+msgstr "Ludzie"
 
 msgctxt "#31034"
 msgid "Cast member"
-msgstr ""
+msgstr "Członek obsady"
 
 msgctxt "#31035"
 msgid "Crew member"
-msgstr ""
+msgstr "Członek ekipy"
 
 #: /1080i/Includes_SkinSettings.xml
 msgctxt "#31036"
 msgid "Limited widgets use Show More folder item"
-msgstr ""
+msgstr "Pokaż folder „Więcej” po przekroczeniu limitu widżetu"
 
 #: /1080i/Includes_SkinSettings.xml
 msgctxt "#31037"
 msgid "Side submenu"
-msgstr ""
+msgstr "Boczne menu podręczne"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31038"
 msgid "Directing"
-msgstr ""
+msgstr "Reżyseria"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31039"
 msgid "Writing"
-msgstr ""
+msgstr "Scenariusz"
 
 #: /1080i/Includes_Views_List.xml
 msgctxt "#31040"
 msgid "List Flixart 2"
-msgstr ""
+msgstr "Lista: Flixart 2"
 
 #: /1080i/Includes_Items.xml
 msgctxt "#31041"
 msgid "Similar"
-msgstr ""
+msgstr "Podobne"
 
 #: /1080i/Dialog_DialogShortcuts.xml
 msgctxt "#31042"
 msgid "Jump to widget"
-msgstr ""
+msgstr "Przejdź do widżetu"
 
 #: /1080i/Custom_1115_Window_Shortcuts.xml
 msgctxt "#31043"
 msgid "Tray"
-msgstr ""
+msgstr "Zasobnik"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31044"
 msgid "Viewtypes"
-msgstr ""
+msgstr "Typy widoku"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31045"
 msgid "Landscape"
-msgstr ""
+msgstr "Baner"
 
 #: /1080i/Includes_Search.xml
 msgctxt "#31046"
 msgid "No Results"
-msgstr ""
+msgstr "Brak wyników"
 
 #: /1080i/Custom_1154_Dialog_SearchDiscover_Sort.xml
 msgctxt "#31047"
 msgid "Popularity"
-msgstr ""
+msgstr "Popularność"
 
 #: /1080i/Custom_1115_Window_Shortcuts.xml
 msgctxt "#31048"
 msgid "tiles"
-msgstr ""
+msgstr "kafelki"
 
 #: /1080i/Includes_SkinSettings.xml
 msgctxt "#31049"
 msgid "Customise shortcuts and widgets"
-msgstr ""
+msgstr "Dostosuj skróty i widżety"
 
 #: /1080i/Includes_Search.xml
 msgctxt "#31050"
 msgid "Crew"
-msgstr ""
+msgstr "Ekipa filmowa"
 
 #: /1080i/Custom_1153_Dialog_SearchDiscover_Actors.xml
 msgctxt "#31051"
 msgid "Person"
-msgstr ""
+msgstr "Osoba"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31052"
 msgid "Sound"
-msgstr ""
+msgstr "Dźwięk"
 
 msgctxt "#31053"
 msgid "Profile"
-msgstr ""
+msgstr "Profil"
 
 msgctxt "#31054"
 msgid "Liked by"
-msgstr ""
+msgstr "Polubione przez"
 
 msgctxt "#31055"
 msgid "out of"
-msgstr ""
+msgstr "z"
 
 msgctxt "#31056"
 msgid "critics"
-msgstr ""
+msgstr "krytyków"
 
 msgctxt "#31057"
 msgid "Years Old"
-msgstr ""
+msgstr "lat"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31058"
 msgid "Wrap"
-msgstr ""
+msgstr "Zawijanie"
 
 #: /1080i/Includes_SkinSettings.xml
 msgctxt "#31059"
 msgid "Side"
-msgstr ""
+msgstr "Z lewej"
 
 #: /1080i/Includes_SkinSettings.xml
 msgctxt "#31060"
 msgid "Slide"
-msgstr ""
+msgstr "Zsuń przy aktywacji menu"
 
 #: /shortcuts/template.xml
 msgctxt "#31061"
 msgid "User rating"
-msgstr ""
+msgstr "Ocena użytkownika"
 
 #: /shortcuts/template.xml
 msgctxt "#31062"
 msgid "Playlist order"
-msgstr ""
+msgstr "Kolejność playlisty"
 
 #: /shortcuts/template.xml
 msgctxt "#31063"
 msgid "Watched episodes"
-msgstr ""
+msgstr "Obejrzane odcinki"
 
 msgctxt "#31064"
 msgid "Awards"
-msgstr ""
+msgstr "Nagrody"
 
 msgctxt "#31065"
 msgid "Creator"
-msgstr ""
+msgstr "Twórca"
 
 #: /1080i/Includes_Search.xml
 msgctxt "#31066"
 msgid "Discover"
-msgstr ""
+msgstr "Odkrywaj"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31067"
 msgid "Cinematography"
-msgstr ""
+msgstr "Zdjęcia"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31068"
 msgid "Experimental"
-msgstr ""
+msgstr "Eksperymentalne"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31069"
 msgid "Background video"
-msgstr ""
+msgstr "Wideo w tle"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31070"
 msgid "Fixed aspect ratio"
-msgstr ""
+msgstr "Stałe proporcje ekranu"
 
 msgctxt "#31071"
 msgid "Playback Speed"
-msgstr ""
+msgstr "Prędkość odtwarzania"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31072"
 msgid "Art Department"
-msgstr ""
+msgstr "Scenografia"
 
 msgctxt "#31073"
 msgid "mins"
-msgstr ""
+msgstr "min"
 
 msgctxt "#31074"
 msgid "hr"
-msgstr ""
+msgstr "h"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31075"
 msgid "Editing"
-msgstr ""
+msgstr "Montaż"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31076"
 msgid "Starring"
-msgstr ""
+msgstr "W rolach głównych"
 
 msgctxt "#31077"
 msgid "More Information"
-msgstr ""
+msgstr "Więcej informacji"
 
 #: /1080i/Includes_SkinSettings.xml
 msgctxt "#31078"
 msgid "Use fake label textboxes"
-msgstr ""
+msgstr "Etykiety zamiast pól tekstowych"
 
 #: /1080i/Includes_SkinSettings.xml
 msgctxt "#31079"
 msgid "improves performance on Omega"
-msgstr ""
+msgstr "poprawia wydajność w Kodi Omega"
 
 #: /1080i/Dialog_DialogCustom.xml
 msgctxt "#31080"
 msgid "Button"
-msgstr ""
+msgstr "Przycisk"
 
 #: /1080i/Dialog_DialogCustom.xml
 msgctxt "#31081"
 msgid "Others"
-msgstr ""
+msgstr "Inne"
 
 #: /1080i/Includes_SkinSettings.xml
 msgctxt "#31082"
 msgid "Ratings style"
-msgstr ""
+msgstr "Styl ocen"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31083"
 msgid "Combined"
-msgstr ""
+msgstr "Łączony"
 
 #: /1080i/Includes_SkinSettings.xml
 msgctxt "#31084"
 msgid "Preload hubs during startup initialisation"
-msgstr ""
+msgstr "Ładuj huby podczas uruchamiania"
 
 msgctxt "#31085"
 msgid "Live TV"
-msgstr ""
+msgstr "TV na żywo"
 
 msgctxt "#31086"
 msgid "Customise options"
-msgstr ""
+msgstr "Dostosuj opcje"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31087"
 msgid "Game Saves"
-msgstr ""
+msgstr "Zapisy gier"
 
 #: /1080i/VideoOSDBookmarks.xml
 msgctxt "#31088"
 msgid "No bookmarks"
-msgstr ""
+msgstr "Brak zakładek"
 
 #: /1080i/VideoOSDBookmarks.xml
 msgctxt "#31089"
 msgid "Add a bookmark here"
-msgstr ""
+msgstr "Dodaj zakładkę"
 
 msgctxt "#31090"
 msgid "In-Progress"
-msgstr ""
+msgstr "W trakcie"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31091"
 msgid "In-Game Saves"
-msgstr ""
+msgstr "Zapisy w grze"
 
 #: /1080i/SkinSettings.xml /1080i/Includes_Shortcuts_Window.xml
 msgctxt "#31092"
 msgid "Detailed information"
-msgstr ""
+msgstr "Szczegółowe informacje"
 
 #: /1080i/Includes_SkinSettings.xml
 msgctxt "#31093"
 msgid "Cycle extra fanart"
-msgstr ""
+msgstr "Pokazuj dodatkowe fanarty"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31094"
 msgid "Mouse pointer size"
-msgstr ""
+msgstr "Rozmiar kursora"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31095"
 msgid "Translations"
-msgstr ""
+msgstr "Tłumaczenia"
 
 #: /1080i/Dialog_DialogPictureInfo.xml
 msgctxt "#31096"
 msgid "plays"
-msgstr ""
+msgstr "odtworzenia"
 
 #: /1080i/Includes_DialogInfo.xml
 msgctxt "#31097"
 msgid "File details"
-msgstr ""
+msgstr "Szczegóły pliku"
 
 #: /1080i/SkinSettings.xml /1080i/Includes_Items.xml
 msgctxt "#31098"
 msgid "Gallery"
-msgstr ""
+msgstr "Galeria"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31099"
 msgid "Last aired"
-msgstr ""
+msgstr "Ostatnia emisja"
 
 #: /1080i/Includes_Views_Row.xml
 msgctxt "#31100"
 msgid "Row Board"
-msgstr ""
+msgstr "Karuzela: Banery kinowe"
 
 #: /1080i/Includes_Views_Wall.xml
 msgctxt "#31101"
 msgid "Wall Board"
-msgstr ""
+msgstr "Siatka: Banery kinowe"
 
 #: /1080i/Includes_DialogInfo.xml
 msgctxt "#31102"
 msgid "Extension"
-msgstr ""
+msgstr "Rozszerzenie"
 
 msgctxt "#31103"
 msgid "Widgets"
-msgstr ""
+msgstr "Widżety"
 
 #: /1080i/Includes_SkinSettings.xml
 msgctxt "#31104"
 msgid "Position"
-msgstr ""
+msgstr "Pozycja"
 
 msgctxt "#31105"
 msgid "Spotlight"
-msgstr ""
+msgstr "Wyróżnione"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31106"
 msgid "Top"
-msgstr ""
+msgstr "U góry"
 
 #: /1080i/Dialog_DialogGameControllers.xml
 msgctxt "#31107"
 msgid "Edit buttons"
-msgstr ""
+msgstr "Edytuj przyciski"
 
 msgctxt "#31108"
 msgid "Collections"
-msgstr ""
+msgstr "Kolekcje"
 
 #: /1080i/Dialog_DialogPVRGroupManager.xml
 msgctxt "#31109"
 msgid "Edit group"
-msgstr ""
+msgstr "Edytuj grupę"
 
 #: /1080i/Includes_Info.xml
 msgctxt "#31110"
 msgid "Starts at"
-msgstr ""
+msgstr "Seans od"
 
 msgctxt "#31111"
 msgid "Row Poster"
-msgstr ""
+msgstr "Karuzela: Plakaty"
 
 msgctxt "#31112"
 msgid "Row Landscape"
-msgstr ""
+msgstr "Karuzela: Banery"
 
 msgctxt "#31113"
 msgid "Row Square"
-msgstr ""
+msgstr "Karuzela: Kwadraty"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31114"
 msgid "Hubs"
-msgstr ""
+msgstr "Huby"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31115"
 msgid "Australian summer"
-msgstr ""
+msgstr "Australijskie lato"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31116"
 msgid "Winter frost"
-msgstr ""
+msgstr "Zimowy szron"
 
 #: /1080i/DialogPlayerProcessInfo.xml
 msgctxt "#31117"
 msgid "RAM"
-msgstr ""
+msgstr "RAM"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31118"
 msgid "Expanded"
-msgstr ""
+msgstr "Rozwinięty"
 
 #: /1080i/DialogPlayerProcessInfo.xml
 msgctxt "#31119"
 msgid "EOTF and Gamut"
-msgstr ""
+msgstr "EOTF i Gamut"
 
 #: /1080i/Includes_Views_List.xml
 msgctxt "#31120"
 msgid "List Basic"
-msgstr ""
+msgstr "Lista: Banery"
 
 #: /1080i/Dialog_FileBrowser.xml
 msgctxt "#31121"
 msgid "Mirror"
-msgstr ""
+msgstr "Mirror"
 
 #: /1080i/Includes_MediaFilter.xml
 msgctxt "#31122"
 msgid "Watchlist"
-msgstr ""
+msgstr "Kolejka"
 
 #: /1080i/Includes_SkinSettings.xml
 msgctxt "#31123"
 msgid "Plot line"
-msgstr ""
+msgstr "Zarys fabuły"
 
 msgctxt "#31124"
 msgid "Indicator"
-msgstr ""
+msgstr "Wskaźnik"
 
 msgctxt "#31125"
 msgid "Invert Text Colour"
-msgstr ""
+msgstr "Odwróć kolor tekstu"
 
 #: /1080i/Includes_SkinSettings.xml
 msgctxt "#31126"
 msgid "Plotline"
-msgstr ""
+msgstr "Linia informacyjna"
 
 #: /1080i/Includes_SkinSettings.xml
 msgctxt "#31127"
 msgid "Genre colours"
-msgstr ""
+msgstr "Kolorowanie według gatunków"
 
 #: /1080i/Includes_MediaFilter.xml
 msgctxt "#31128"
 msgid "Trending"
-msgstr ""
+msgstr "Popularne"
 
 msgctxt "#31129"
 msgid "Up next in"
-msgstr ""
+msgstr "Następny za"
 
 msgctxt "#31130"
 msgid "seconds"
-msgstr ""
+msgstr "s"
 
 msgctxt "#31131"
 msgid "Continue watching in"
-msgstr ""
+msgstr "Oglądasz? Koniec za"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31134"
 msgid "Playing"
-msgstr ""
+msgstr "Odtwarzanie"
 
 #: /1080i/Includes_Views.xml
 msgctxt "#31135"
 msgid "Page"
-msgstr ""
+msgstr "Strona"
 
 #: /1080i/SkinSettings.xml /1080i/Includes_Labels.xml
 msgctxt "#31137"
 msgid "Detailed"
-msgstr ""
+msgstr "Szczegółowe"
 
 msgctxt "#31138"
 msgid "Aqua Classic"
-msgstr ""
+msgstr "Aqua Classic"
 
 msgctxt "#31139"
 msgid "Tropical Sunset"
-msgstr ""
+msgstr "Tropikalny Zachód"
 
 msgctxt "#31140"
 msgid "Miami Vaporwave"
-msgstr ""
+msgstr "Miami Vaporwave"
 
 msgctxt "#31141"
 msgid "Plain Monochrome"
-msgstr ""
+msgstr "Surowy Monochrom"
 
 msgctxt "#31142"
 msgid "Total Duration"
-msgstr ""
+msgstr "Czas trwania"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31143"
 msgid "Classic"
-msgstr ""
+msgstr "Klasyczny"
 
 msgctxt "#31145"
 msgid "Initialising Skin"
-msgstr ""
+msgstr "Inicjowanie skina"
 
 #: /1080i/Includes_Shortcuts_Window.xml
 msgctxt "#31147"
 msgid "More"
-msgstr ""
+msgstr "Więcej"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31150"
 msgid "Categories"
-msgstr ""
+msgstr "Kategorie"
 
 msgctxt "#31154"
 msgid "Misc options"
-msgstr ""
+msgstr "Pozostałe"
 
 #: /1080i/Includes_Keyboard_Mini.xml
 msgctxt "#31158"
 msgid "Layout"
-msgstr ""
+msgstr "Układ"
 
 #: /1080i/Custom_1120_VideoInfo_Details.xml
 msgctxt "#31159"
 msgid "Version"
-msgstr ""
+msgstr "Wersja"
 
 msgctxt "#31160"
 msgid "REC"
-msgstr ""
+msgstr "NAGRYWANIE"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31162"
 msgid "Hide"
-msgstr ""
+msgstr "Ukryj"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31165"
 msgid "Seekbar behaviour on delayed pause"
-msgstr ""
+msgstr "Pasek postępu: Akcja pauzy"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31166"
 msgid "Back"
-msgstr ""
+msgstr "Element powrotny"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31167"
 msgid "Logo"
-msgstr ""
+msgstr "Logo"
 
 #: /1080i/Includes_Views_List.xml
 msgctxt "#31168"
 msgid "List Square"
-msgstr ""
+msgstr "Lista: Kwadraty"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31169"
 msgid "Birthday"
-msgstr ""
+msgstr "Urodziny"
 
 #: /1080i/Custom_1115_Dialog_Shortcuts_Window.xml
 msgctxt "#31170"
 msgid "Note"
-msgstr ""
+msgstr "Uwaga"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31171"
 msgid "On-screen keyboard size"
-msgstr ""
+msgstr "Rozmiar klawiatury ekranowej"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31173"
 msgid "Scroll"
-msgstr ""
+msgstr "Przewijanie"
 
 msgctxt "#31174"
 msgid "Navigation"
-msgstr ""
+msgstr "Nawigacja"
 
 msgctxt "#31177"
 msgid "Menus"
-msgstr ""
+msgstr "Menu"
 
 #: /1080i/Includes_Search.xml
 msgctxt "#31179"
 msgid "Keyword"
-msgstr ""
+msgstr "Słowo kluczowe"
 
 #: /1080i/Includes_DialogInfo.xml
 msgctxt "#31181"
 msgid "Scheduled"
-msgstr ""
+msgstr "Zaplanowane"
 
 #: /1080i/Includes_Info.xml
 msgctxt "#31183"
 msgid "times"
-msgstr ""
+msgstr "razy"
 
 #: /1080i/Includes_Info.xml
 msgctxt "#31184"
 msgid "Ends"
-msgstr ""
+msgstr "Kończy się"
 
 msgctxt "#31185"
 msgid "Autoscroll"
-msgstr ""
+msgstr "Autoprzewijanie"
 
 msgctxt "#31186"
 msgid "Behaviour"
-msgstr ""
+msgstr "Zachowanie"
 
 msgctxt "#31187"
 msgid "Autoscroll time interval"
-msgstr ""
+msgstr "Częstotliwość automatycznego przewijania"
 
 msgctxt "#31188"
 msgid "Limit"
-msgstr ""
+msgstr "Limit"
 
 msgctxt "#31189"
 msgid "Autoclose OSD after X seconds"
-msgstr ""
+msgstr "Czas wyświetlania OSD"
 
 #: /1080i/Includes_Info.xml
 msgctxt "#31194"
 msgid "Album duration"
-msgstr ""
+msgstr "Długość albumu"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31195"
 msgid "Light"
-msgstr ""
+msgstr "Jasny"
 
 msgctxt "#31196"
 msgid "Up Next"
-msgstr ""
+msgstr "Następnie"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31197"
 msgid "Skin theme"
-msgstr ""
+msgstr "Motyw skina"
 
 #: /1080i/Includes_Info.xml
 msgctxt "#31198"
 msgid "Track duration"
-msgstr ""
+msgstr "Długość utworu"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31199"
 msgid "Date and time"
-msgstr ""
+msgstr "Data i godzina"
 
 #: /1080i/Includes_Info.xml
 msgctxt "#31200"
 msgid "Added on"
-msgstr ""
+msgstr "Dodano"
 
 msgctxt "#31202"
 msgid "Ratings"
-msgstr ""
+msgstr "Oceny"
 
 msgctxt "#31203"
 msgid "Customise"
-msgstr ""
+msgstr "Dostosuj"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31204"
 msgid "Customise dialog background"
-msgstr ""
+msgstr "Kolor okien dialogowych"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31205"
 msgid "Codecs and providers"
-msgstr ""
+msgstr "Kodeki i dostawcy"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31206"
 msgid "Item count"
-msgstr ""
+msgstr "Liczba elementów"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31207"
 msgid "Codecs"
-msgstr ""
+msgstr "Kodeki"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31208"
 msgid "Header"
-msgstr ""
+msgstr "Nagłówek"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31209"
 msgid "Boxes"
-msgstr ""
+msgstr "Ramki"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31210"
 msgid "Series Premiere"
-msgstr ""
+msgstr "Premiera serialu"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31211"
 msgid "Season Premiere"
-msgstr ""
+msgstr "Premiera sezonu"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31212"
 msgid "Mid-Season Premiere"
-msgstr ""
+msgstr "Kontynuacja sezonu"
 
 msgctxt "#31213"
 msgid "Visualisation settings"
-msgstr ""
+msgstr "Ustawienia wizualizacji"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31214"
 msgid "Series Finale"
-msgstr ""
+msgstr "Finał serialu"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31215"
 msgid "Season Finale"
-msgstr ""
+msgstr "Finał sezonu"
 
 msgctxt "#31216"
 msgid "Video decoder"
-msgstr ""
+msgstr "Dekoder wideo"
 
 msgctxt "#31217"
 msgid "Pixel format"
-msgstr ""
+msgstr "Format pikseli"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31218"
 msgid "Mid-Season Finale"
-msgstr ""
+msgstr "Finał połowy sezonu"
 
 #: /1080i/Includes_Items.xml
 msgctxt "#31220"
 msgid "Purple"
-msgstr ""
+msgstr "Fioletowy"
 
 #: /1080i/Includes_Items.xml
 msgctxt "#31221"
 msgid "Slate"
-msgstr ""
+msgstr "Łupkowy"
 
 #: /1080i/Includes_Items.xml
 msgctxt "#31222"
 msgid "Coal"
-msgstr ""
+msgstr "Węglowy"
 
 msgctxt "#31223"
 msgid "Gridlines"
-msgstr ""
+msgstr "Linie siatki"
 
 #: /1080i/Includes_Items.xml
 msgctxt "#31224"
 msgid "Pink"
-msgstr ""
+msgstr "Różowy"
 
 #: /1080i/Includes_Items.xml
 msgctxt "#31225"
 msgid "Chalk"
-msgstr ""
+msgstr "Kredowy"
 
 #: /1080i/Includes_Items.xml
 msgctxt "#31226"
 msgid "Blush"
-msgstr ""
+msgstr "Rumiany"
 
 #: /1080i/Includes_Items.xml
 msgctxt "#31227"
 msgid "Premiere"
-msgstr ""
+msgstr "Premiera"
 
 #: /1080i/Custom_1115_Dialog_ColourPresets.xml
 msgctxt "#31228"
 msgid "Aqua"
-msgstr ""
+msgstr "Aqua"
 
 #: /1080i/Custom_1115_Dialog_ColourPresets.xml
 msgctxt "#31229"
 msgid "Vaporwave"
-msgstr ""
+msgstr "Vaporwave"
 
 #: /1080i/Includes_Items.xml
 msgctxt "#31230"
 msgid "Calendar"
-msgstr ""
+msgstr "Kalendarz"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31231"
 msgid "Customise highlight colours"
-msgstr ""
+msgstr "Kolor podświetlenia"
 
 #: /1080i/Custom_1111_Dialog_ColourPicker.xml
 msgctxt "#31232"
 msgid "Gradient"
-msgstr ""
+msgstr "Gradient"
 
 msgctxt "#31233"
 msgid "Seek to"
-msgstr ""
+msgstr "Przewiń do"
 
 msgctxt "#31234"
 msgid "Customise indicators"
-msgstr ""
+msgstr "Dostosuj wskaźniki"
 
 msgctxt "#31235"
 msgid "Indicators"
-msgstr ""
+msgstr "Wskaźniki"
 
 msgctxt "#31236"
 msgid "Collection"
-msgstr ""
+msgstr "Kolekcja"
 
 msgctxt "#31237"
 msgid "Progress"
-msgstr ""
+msgstr "Postęp"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31238"
 msgid "Coral"
-msgstr ""
+msgstr "Koralowy"
 
 msgctxt "#31239"
 msgid "Footer"
-msgstr ""
+msgstr "Stopka"
 
 #: /1080i/Custom_1115_Dialog_ColourPresets.xml
 msgctxt "#31240"
 msgid "Tropical"
-msgstr ""
+msgstr "Tropikalny"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31241"
 msgid "Colour scheme"
-msgstr ""
+msgstr "Schemat kolorów"
 
 #: /1080i/Includes_Items.xml
 msgctxt "#31242"
 msgid "Blue Slate"
-msgstr ""
+msgstr "Niebiesko-łupkowy"
 
 #: /1080i/Includes_Items.xml
 msgctxt "#31243"
 msgid "Midnight Purple"
-msgstr ""
+msgstr "Nocny fiolet"
 
 msgctxt "#31244"
 msgid "Now playing"
-msgstr ""
+msgstr "W trakcie odtwarzania"
 
 msgctxt "#31245"
 msgid "Autoscroll labels"
-msgstr ""
+msgstr "Automatyczne przewijanie etykiet"
 
 msgctxt "#31246"
 msgid "Autoscroll textboxes"
-msgstr ""
+msgstr "Automatyczne przewijanie pól tekstowych"
 
 msgctxt "#31249"
 msgid "Waiting for PVR"
-msgstr ""
+msgstr "Oczekiwanie na PVR"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31250"
 msgid "Highlight"
-msgstr ""
+msgstr "Podświetlenie"
 
 msgctxt "#31252"
 msgid "Catch-up"
-msgstr ""
+msgstr "Catch-up"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31254"
 msgid "Performance"
-msgstr ""
+msgstr "Wydajność"
 
 msgctxt "#31255"
 msgid "Customise startup image"
-msgstr ""
+msgstr "Obraz startowy"
 
 msgctxt "#31256"
 msgid "Resource Usage"
-msgstr ""
+msgstr "Użycie zasobów"
 
 msgctxt "#31257"
 msgid "Memory"
-msgstr ""
+msgstr "Pamięć"
 
 msgctxt "#31258"
 msgid "CPU"
-msgstr ""
+msgstr "CPU"
 
 msgctxt "#31259"
 msgid "FPS"
-msgstr ""
+msgstr "FPS"
 
 msgctxt "#31260"
 msgid "AR"
-msgstr ""
+msgstr "AR"
 
 msgctxt "#31261"
 msgid "px"
-msgstr ""
+msgstr "px"
 
 msgctxt "#31262"
 msgid "Hz"
-msgstr ""
+msgstr "Hz"
 
 msgctxt "#31263"
 msgid "bits"
-msgstr ""
+msgstr "bitów"
 
 msgctxt "#31264"
 msgid "Revenue"
-msgstr ""
+msgstr "Przychód"
 
 msgctxt "#31265"
 msgid "Budget"
-msgstr ""
+msgstr "Budżet"
 
 msgctxt "#31270"
 msgid "Single image"
-msgstr ""
+msgstr "Pojedynczy obraz"
 
 msgctxt "#31271"
 msgid "Image folder"
-msgstr ""
+msgstr "Folder z obrazami"
 
 #: /1080i/Includes_Search_View.xml
 msgctxt "#31272"
 msgid "Searching"
-msgstr ""
+msgstr "Wyszukiwanie"
 
 msgctxt "#31273"
 msgid "Label"
-msgstr ""
+msgstr "Etykieta"
 
 #: /1080i/Includes_Items.xml
 msgctxt "#31274"
 msgid "Icon"
-msgstr ""
+msgstr "Ikona"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31275"
 msgid "Customise search"
-msgstr ""
+msgstr "Wyszukiwanie"
 
 msgctxt "#31279"
 msgid "Studio icons"
-msgstr ""
+msgstr "Ikony wytwórni"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31281"
 msgid "Welcome"
-msgstr ""
+msgstr "Witaj"
 
 #: /1080i/Includes_Shortcuts_Pallette.xml
 msgctxt "#31282"
 msgid "Widget"
-msgstr ""
+msgstr "Widżet"
 
 #: /1080i/Includes_Info.xml
 msgctxt "#31283"
 msgid "Played"
-msgstr ""
+msgstr "Odtworzone"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31284"
 msgid "Discover movies and tvshows on TMDb."
-msgstr ""
+msgstr "Odkrywaj filmy i seriale w TMDb."
 
 msgctxt "#31285"
 msgid "Classification (MPAA)"
-msgstr ""
+msgstr "Kategoria wiekowa (MPAA)"
 
 msgctxt "#31286"
 msgid "Won"
-msgstr ""
+msgstr "Wygrane"
 
 msgctxt "#31287"
 msgid "Nominated for"
-msgstr ""
+msgstr "Nominacje do"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31288"
 msgid "Explore now."
-msgstr ""
+msgstr "Przeglądaj teraz."
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31289"
 msgid "Touch mode"
-msgstr ""
+msgstr "Tryb dotykowy"
 
 #: /1080i/script-wikipedia.xml
 msgctxt "#31290"
 msgid "Attribution"
-msgstr ""
+msgstr "Przypisanie autorstwa"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31291"
 msgid "Search for movies$COMMA tvshows$COMMA and more."
-msgstr ""
+msgstr "Szukaj filmów, seriali i nie tylko..."
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31292"
 msgid "Text labels"
-msgstr ""
+msgstr "Etykiety tekstowe"
 
 msgctxt "#31293"
 msgid "Cast and more info"
-msgstr ""
+msgstr "Obsada"
 
 msgctxt "#31294"
 msgid "Bookmarks and chapters"
-msgstr ""
+msgstr "Zakładki i rozdziały"
 
 msgctxt "#31295"
 msgid "Channels"
-msgstr ""
+msgstr "Kanały"
 
 msgctxt "#31296"
 msgid "Playlist"
-msgstr ""
+msgstr "Lista odtwarzania"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31297"
 msgid "Extra fanart"
-msgstr ""
+msgstr "Dodatkowy fanart"
 
 msgctxt "#31298"
 msgid "Movies and tv shows starring this actor"
-msgstr ""
+msgstr "Filmy i seriale z udziałem tego aktora"
 
 msgctxt "#31299"
 msgid "Information is loading"
-msgstr ""
+msgstr "Ładowanie informacji"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31300"
 msgid "Customise window background"
-msgstr ""
+msgstr "Kolor interfejsu"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31301"
 msgid "Crew"
-msgstr ""
+msgstr "Ekipa filmowa"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31303"
 msgid "Customise fallback image folder"
-msgstr ""
+msgstr "Folder grafik rezerwowych"
 
 #: /1080i/Includes_Search.xml
 msgctxt "#31304"
 msgid "lists"
-msgstr ""
+msgstr "listy"
 
 #: /1080i/Includes_DialogInfo.xml
 msgctxt "#31307"
 msgid "Instrument"
-msgstr ""
+msgstr "Instrument"
 
 #: /1080i/Includes_DialogInfo.xml
 msgctxt "#31308"
 msgid "Mood"
-msgstr ""
+msgstr "Nastrój"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31309"
 msgid "Glass"
-msgstr ""
+msgstr "Szkło"
 
 #: /1080i/Custom_1161_Dialog_Weather.xml
 msgctxt "#31310"
 msgid "Expand"
-msgstr ""
+msgstr "Rozwiń"
 
 #: /1080i/Custom_1161_Dialog_Weather.xml
 msgctxt "#31311"
 msgid "Weekly"
-msgstr ""
+msgstr "Tygodniowy"
 
 #: /1080i/Includes_MediaFilter.xml
 msgctxt "#31319"
 msgid "View"
-msgstr ""
+msgstr "Widok"
 
 #: /1080i/Includes_Views.xml
 msgctxt "#31320"
 msgid "Square"
-msgstr ""
+msgstr "Kwadrat"
 
 #: /1080i/Includes_SkinSettings.xml
 msgctxt "#31321"
 msgid "Select viewtypes"
-msgstr ""
+msgstr "Typy widoków"
 
 #: /1080i/SkinSettings.xml /1080i/Includes_Labels.xml
 msgctxt "#31322"
 msgid "Age"
-msgstr ""
+msgstr "Wiek"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31324"
 msgid "Content"
-msgstr ""
+msgstr "Nawigacja"
 
 #: /1080i/Custom_1116_Dialog_Shortcuts.xml
 msgctxt "#31328"
 msgid "Edit widgets"
-msgstr ""
+msgstr "Edytuj widżety"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31329"
 msgid "Text"
-msgstr ""
+msgstr "Tekst"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31330"
 msgid "Crop"
-msgstr ""
+msgstr "Kadrowanie"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31331"
 msgid "Background style"
-msgstr ""
+msgstr "Styl tła"
 
 msgctxt "#31334"
 msgid "Comments"
-msgstr ""
+msgstr "Komentarze"
 
 #: /1080i/GameOSD.xml
 msgctxt "#31335"
 msgid "Game menu"
-msgstr ""
+msgstr "Menu gry"
 
 #: /1080i/GameOSD.xml
 msgctxt "#31336"
 msgid "Select + X"
-msgstr ""
+msgstr "Select + X"
 
 #: /1080i/GameOSD.xml
 msgctxt "#31337"
 msgid "Select + Start"
-msgstr ""
+msgstr "Select + Start"
 
 #: /1080i/Includes_Items.xml
 msgctxt "#31338"
 msgid "Select + Right Stick"
-msgstr ""
+msgstr "Select + Prawy analog"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31340"
 msgid "Reset skin to defaults"
-msgstr ""
+msgstr "Przywróć ustawienia domyślne skina"
 
 msgctxt "#31346"
 msgid "More by this artist"
-msgstr ""
+msgstr "Więcej tego wykonawcy"
 
 #: /1080i/Includes_DialogInfo.xml
 msgctxt "#31347"
 msgid "Photography"
-msgstr ""
+msgstr "Zdjęcia"
 
 msgctxt "#31348"
 msgid "Channel EPG"
-msgstr ""
+msgstr "EPG kanału"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31349"
 msgid "Up"
-msgstr ""
+msgstr "W górę"
 
 msgctxt "#31350"
 msgid "Thanks"
-msgstr ""
+msgstr "Podziękowania"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31353"
 msgid "Elapsed"
-msgstr ""
+msgstr "Upłynęło"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31354"
 msgid "Remaining"
-msgstr ""
+msgstr "Pozostało"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31355"
 msgid "Seekbar time display"
-msgstr ""
+msgstr "Pasek postępu: Format czasu"
 
 #: /1080i/Includes_Items.xml
 msgctxt "#31356"
 msgid "Use online cast"
-msgstr ""
+msgstr "Używaj obsady online"
 
 #: /1080i/SkinSettings.xml /1080i/Includes_Items.xml
 msgctxt "#31357"
 msgid "Artwork Overlay"
-msgstr ""
+msgstr "Nakładki graficzne"
 
 msgctxt "#31358"
 msgid "Waiting for plugins"
-msgstr ""
+msgstr "Oczekiwanie na wtyczki"
 
 #: /shortcuts/generator/data/setup/powermenu_item.xml
 msgctxt "#31359"
 msgid "Switch user"
-msgstr ""
+msgstr "Przełącz użytkownika"
 
 #: /1080i/Includes_Items.xml
 msgctxt "#31362"
 msgid "Side items"
-msgstr ""
+msgstr "Elementy boczne"
 
 #: /1080i/Includes_Items.xml
 msgctxt "#31363"
 msgid "Menu items"
-msgstr ""
+msgstr "Elementy menu"
 
 #: /shortcuts/powersubmenu.DATA.xml
 msgctxt "#31364"
 msgid "Reload"
-msgstr ""
+msgstr "Przeładuj"
 
 #: /1080i/DialogContextMenu.xml
 msgctxt "#31365"
 msgid "Node"
-msgstr ""
+msgstr "Węzeł"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31366"
 msgid "Uncropped"
-msgstr ""
+msgstr "Niekadrowane"
 
 #: /1080i/Includes_Search_View.xml
 msgctxt "#31368"
 msgid "Searching for"
-msgstr ""
+msgstr "Wyszukiwanie"
 
 #: /1080i/Includes_Items.xml
 msgctxt "#31369"
 msgid "Video file"
-msgstr ""
+msgstr "Plik wideo"
 
 #: /1080i/Custom_1172_Dialog_SideMenu.xml
 msgctxt "#31370"
 msgid "Switch profile"
-msgstr ""
+msgstr "Przełącz profil"
 
 msgctxt "#31371"
 msgid "Sorted by"
-msgstr ""
+msgstr "Posortowane według"
 
 #: /1080i/Includes_Items.xml
 msgctxt "#31372"
 msgid "Options tray"
-msgstr ""
+msgstr "Panel opcji"
 
 #: /1080i/Includes_DialogInfo.xml
 msgctxt "#31373"
 msgid "from"
-msgstr ""
+msgstr "z"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31374"
 msgid "Reset skin settings to defaults"
-msgstr ""
+msgstr "Przywróć ustawienia domyślne skina"
 
 msgctxt "#31375"
 msgid "Install zip"
-msgstr ""
+msgstr "Zainstaluj z .zip"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31376"
 msgid "Reset discover search history"
-msgstr ""
+msgstr "Wyczyść historię wyszukiwania"
 
 #: /1080i/Includes_Shortcuts_Window.xml
 msgctxt "#31377"
 msgid "Next window"
-msgstr ""
+msgstr "Następne okno"
 
 msgctxt "#31378"
 msgid "Foreign"
-msgstr ""
+msgstr "Zagraniczne"
 
 #: /1080i/Custom_1116_Dialog_Shortcuts.xml
 msgctxt "#31379"
 msgid "Edit categories"
-msgstr ""
+msgstr "Edytuj kategorie"
 
 msgctxt "#31380"
 msgid "Forecast"
-msgstr ""
+msgstr "Prognoza"
 
 msgctxt "#31381"
 msgid "Returning"
-msgstr ""
+msgstr "Nowy sezon"
 
 msgctxt "#31382"
 msgid "All items"
-msgstr ""
+msgstr "Wszystkie"
 
 msgctxt "#31383"
 msgid "Production"
-msgstr ""
+msgstr "Produkcja"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31384"
 msgid "Tray labels"
-msgstr ""
+msgstr "Etykiety zasobnika"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31385"
 msgid "Secondary"
-msgstr ""
+msgstr "Drugorzędny"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31386"
 msgid "Primary"
-msgstr ""
+msgstr "Główny"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31387"
 msgid "Contextual"
-msgstr ""
+msgstr "Dodatkowy"
 
 #: /1080i/Custom_1116_Dialog_Shortcuts.xml
 msgctxt "#31388"
 msgid "Seed"
-msgstr ""
+msgstr "Baza"
 
 #: /1080i/Custom_1116_Dialog_Shortcuts.xml
 msgctxt "#31389"
 msgid "Parent widget"
-msgstr ""
+msgstr "Widżet nadrzędny"
 
 msgctxt "#31390"
 msgid "Release Year"
-msgstr ""
+msgstr "Rok wydania"
 
 #: /1080i/Includes_Items.xml Shorter label for use in info dialog buttons
 msgctxt "#31393"
 msgid "Trailer"
-msgstr ""
+msgstr "Zwiastun"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31394"
 msgid "Picture-in-picture video"
-msgstr ""
+msgstr "Obraz w obrazie (PiP)"
 
 msgctxt "#31396"
 msgid "Recent Movies"
-msgstr ""
+msgstr "Ostatnie filmy"
 
 msgctxt "#31397"
 msgid "Recent Tv Shows"
-msgstr ""
+msgstr "Ostatnie seriale"
 
 msgctxt "#31398"
 msgid "New Movies"
-msgstr ""
+msgstr "Nowe filmy"
 
 msgctxt "#31399"
 msgid "New TV Shows"
-msgstr ""
+msgstr "Nowe seriale"
 
 msgctxt "#31400"
 msgid "New Episodes"
-msgstr ""
+msgstr "Nowe odcinki"
 
 msgctxt "#31401"
 msgid "New Artists"
-msgstr ""
+msgstr "Nowi wykonawcy"
 
 msgctxt "#31402"
 msgid "New Albums"
-msgstr ""
+msgstr "Nowe albumy"
 
 msgctxt "#31403"
 msgid "In-Progress TV Shows"
-msgstr ""
+msgstr "Rozpoczęte seriale"
 
 msgctxt "#31404"
 msgid "In-Progress Movies"
-msgstr ""
+msgstr "Rozpoczęte filmy"
 
 msgctxt "#31405"
 msgid "Top Albums"
-msgstr ""
+msgstr "Najlepsze albumy"
 
 msgctxt "#31406"
 msgid "Top Rated Movies"
-msgstr ""
+msgstr "Najwyżej oceniane filmy"
 
 msgctxt "#31407"
 msgid "Top Rated TV Shows"
-msgstr ""
+msgstr "Najwyżej oceniane seriale"
 
 msgctxt "#31408"
 msgid "Random Movies"
-msgstr ""
+msgstr "Losowe filmy"
 
 msgctxt "#31409"
 msgid "Random TV Shows"
-msgstr ""
+msgstr "Losowe seriale"
 
 msgctxt "#31410"
 msgid "Random Episodes"
-msgstr ""
+msgstr "Losowe odcinki"
 
 msgctxt "#31411"
 msgid "Random Songs"
-msgstr ""
+msgstr "Losowe utwory"
 
 msgctxt "#31412"
 msgid "Random Albums"
-msgstr ""
+msgstr "Losowe albumy"
 
 msgctxt "#31413"
 msgid "All Movies"
-msgstr ""
+msgstr "Wszystkie filmy"
 
 msgctxt "#31414"
 msgid "All TV Shows"
-msgstr ""
+msgstr "Wszystkie seriale"
 
 msgctxt "#31415"
 msgid "Movies and TV Shows"
-msgstr ""
+msgstr "Filmy i seriale"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31416"
 msgid "Secondary button"
-msgstr ""
+msgstr "Przycisk dodatkowy"
 
 msgctxt "#31417"
 msgid "Random Artists"
-msgstr ""
+msgstr "Losowi wykonawcy"
 
 #: /1080i/Includes_Views_Row.xml
 msgctxt "#31418"
 msgid "Row Circle"
-msgstr ""
+msgstr "Karuzela: Disc Art"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31419"
 msgid "Overview"
-msgstr ""
+msgstr "Zarys"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31420"
 msgid "Apps"
-msgstr ""
+msgstr "Aplikacje"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31423"
 msgid "Card"
-msgstr ""
+msgstr "Karta"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31424"
 msgid "Board"
-msgstr ""
+msgstr "Tablica"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31425"
 msgid "Labels"
-msgstr ""
+msgstr "Etykiety"
 
 #: /1080i/Home.xml
 msgctxt "#31427"
 msgid "Initialising"
-msgstr ""
+msgstr "Inicjalizacja:"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31428"
 msgid "Hide widget initialisation behind splash"
-msgstr ""
+msgstr "Ukryj ładowanie widżetów pod ekranem powitalnym"
 
 #: /1080i/Includes_Items.xml
 msgctxt "#31429"
 msgid "Chapters"
-msgstr ""
+msgstr "Rozdziały"
 
 #: /1080i/Includes_SkinSettings.xml
 msgctxt "#31430"
 msgid "Customise style"
-msgstr ""
+msgstr "Styl"
 
 #: /1080i/SkinSettings.xml /1080i/Includes_Views_Row.xml
 msgctxt "#31431"
 msgid "Circle"
-msgstr ""
+msgstr "Disc Art"
 
 #: /1080i/Includes_Items.xml
 msgctxt "#31432"
 msgid "Adaptive"
-msgstr ""
+msgstr "Adaptacyjny"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31434"
 msgid "Video OSD"
-msgstr ""
+msgstr "Wideo OSD"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31435"
 msgid "TMDbHelper lookups"
-msgstr ""
+msgstr "– wyszukiwanie w TMDbHelper"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31438"
 msgid "Simple"
-msgstr ""
+msgstr "Proste"
 
 #: /1080i/Includes_Items.xml
 msgctxt "#31439"
 msgid "Large"
-msgstr ""
+msgstr "Duży"
 
 #: /1080i/Includes_Items.xml
 msgctxt "#31440"
 msgid "Extra Large"
-msgstr ""
+msgstr "Bardzo duży"
 
 #: /1080i/Includes_Items.xml
 msgctxt "#31441"
 msgid "FlixArt Size"
-msgstr ""
+msgstr "Rozmiar FlixArt"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31442"
 msgid "Parent"
-msgstr ""
+msgstr "Nadrzędny"
 
 #: /1080i/Settings.xml
 msgctxt "#31444"
 msgid "Customisation"
-msgstr ""
+msgstr "Personalizacja"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31448"
 msgid "This category contains customisation options for"
-msgstr ""
+msgstr "Ta sekcja pozwala dostosować"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31450"
 msgid "Text only"
-msgstr ""
+msgstr "Tylko tekst"
 
 #: /1080i/Custom_1180_Wizard.xml
 msgctxt "#31451"
 msgid "Compound"
-msgstr ""
+msgstr "Złożony"
 
 #: /1080i/Custom_1180_Wizard.xml
 msgctxt "#31452"
 msgid "Composite"
-msgstr ""
+msgstr "Kompozytowy"
 
 #: /1080i/Custom_1115_Dialog_WideSettings.xml
 msgctxt "#31456"
 msgid "Prebuilt"
-msgstr ""
+msgstr "Gotowe szablony"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31457"
 msgid "Scrollbar"
-msgstr ""
+msgstr "Pasek przewijania"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31458"
 msgid "Monochrome"
-msgstr ""
+msgstr "Monochrom"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31459"
 msgid "Letter"
-msgstr ""
+msgstr "Alfabet"
 
 #: /1080i/SkinSettings.xml /1080i/MusicOSD.xml
 msgctxt "#31460"
 msgid "Customise visualisation"
-msgstr ""
+msgstr "Wizualizacja"
 
 #: /1080i/Includes_Items.xml
 msgctxt "#31461"
 msgid "Choose preset"
-msgstr ""
+msgstr "Wybierz preset"
 
 #: /1080i/Includes_Views_Wall.xml
 msgctxt "#31462"
 msgid "Wall Banner"
-msgstr ""
+msgstr "Siatka: Banery"
 
 #: /1080i/Custom_1161_Dialog_Weather.xml
 msgctxt "#31465"
 msgid "Rain chance"
-msgstr ""
+msgstr "Szansa na deszcz"
 
 #: /1080i/Includes_Items.xml
 msgctxt "#31467"
 msgid "Tiles configuration"
-msgstr ""
+msgstr "Kafelki"
 
 #: /1080i/Includes_Items.xml
 msgctxt "#31468"
 msgid "Tile layout"
-msgstr ""
+msgstr "Układ kafelków"
 
 #: /1080i/Includes_Items.xml
 msgctxt "#31469"
 msgid "Choose shortcut"
-msgstr ""
+msgstr "Skrót"
 
 #: /1080i/Custom_1161_Dialog_Weather.xml
 msgctxt "#31470"
 msgid "Wind gusts"
-msgstr ""
+msgstr "Porywy wiatru"
 
 #: /1080i/Custom_1161_Dialog_Weather.xml
 msgctxt "#31471"
 msgid "Fire danger"
-msgstr ""
+msgstr "Zagrożenie pożarowe"
 
 #: /1080i/Custom_1161_Dialog_Weather.xml
 msgctxt "#31472"
 msgid "Rain since 9am"
-msgstr ""
+msgstr "Opady od 9:00"
 
 #: /1080i/Custom_1161_Dialog_Weather.xml
 msgctxt "#31473"
 msgid "Radar"
-msgstr ""
+msgstr "Radar"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31476"
 msgid "This category contains acknowledgements, contributions, and thanks."
-msgstr ""
+msgstr "Ta sekcja zawiera podziękowania oraz listę współtwórców."
 
 #: /1080i/SkinSettings.xml /1080i/Includes_Items.xml
 msgctxt "#31477"
 msgid "Progress percentage"
-msgstr ""
+msgstr "Procent postępu"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31478"
 msgid "by"
-msgstr ""
+msgstr "przez"
 
 #: /1080i/Includes_Views_List.xml
 msgctxt "#31479"
 msgid "List Media"
-msgstr ""
+msgstr "Lista: Plakaty"
 
 #: /1080i/Includes_Views_List.xml
 msgctxt "#31480"
 msgid "List Flixart"
-msgstr ""
+msgstr "Lista: Flixart"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31482"
 msgid "Trailers"
-msgstr ""
+msgstr "Zwiastuny"
 
 #: /1080i/Custom_1123_Dialog_Trailer.xml
 msgctxt "#31483"
 msgid "Replay"
-msgstr ""
+msgstr "Odtwórz ponownie"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31484"
 msgid "Pause"
-msgstr ""
+msgstr "Pauza"
 
 #: /1080i/Custom_1123_Dialog_Trailer.xml
 msgctxt "#31485"
 msgid "Stop"
-msgstr ""
+msgstr "Stop"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31486"
 msgid "Dialog"
-msgstr ""
+msgstr "Okna dialogowe"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31487"
 msgid "and"
-msgstr ""
+msgstr "oraz"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31490"
 msgid "Cancelled"
-msgstr ""
+msgstr "Anulowany"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31491"
 msgid "Miscellaneous"
-msgstr ""
+msgstr "Pozostałe opcje"
 
 #: /1080i/Includes_Actions.xml
 msgctxt "#31492"
 msgid "Add-ons hub"
-msgstr ""
+msgstr "Centrum dodatków"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31493"
 msgid "Ended"
-msgstr ""
+msgstr "Zakończony"
 
 #: /1080i/Custom_1115_Dialog_Shortcuts.xml
 msgctxt "#31494"
 msgid "Rebuild"
-msgstr ""
+msgstr "Przebuduj"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31495"
 msgid "Unlocked"
-msgstr ""
+msgstr "Odblokowany"
 
 #: /1080i/Includes_Items.xml
 msgctxt "#31496"
 msgid "Customise widgets"
-msgstr ""
+msgstr "Widżety"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31497"
 msgid "Minimise menu"
-msgstr ""
+msgstr "Minimalizuj menu"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31498"
 msgid "Released"
-msgstr ""
+msgstr "Wydany"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31499"
 msgid "In-Production"
-msgstr ""
+msgstr "W produkcji"
 
 #: /1080i/Includes_Search.xml
 msgctxt "#31500"
 msgid "There were no search results found"
-msgstr ""
+msgstr "Brak wyników wyszukiwania"
 
 #: /1080i/Includes_Search.xml
 msgctxt "#31501"
 msgid "Please try another search"
-msgstr ""
+msgstr "Spróbuj wyszukać coś innego"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31502"
 msgid "More Options"
-msgstr ""
+msgstr "Więcej opcji"
 
 #: /1080i/DialogVideoVersion.xml
 msgctxt "#31503"
 msgid "Extras"
-msgstr ""
+msgstr "Dodatki"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31504"
 msgid "Planned"
-msgstr ""
+msgstr "Zapowiedziany"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31505"
 msgid "Skin user login screen on startup"
-msgstr ""
+msgstr "Ekran wyboru profilu przy starcie"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31506"
 msgid "Individual skin user widget configurations"
-msgstr ""
+msgstr "Konfiguracja widżetów per użytkownik"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31507"
 msgid "pseudo profiles"
-msgstr ""
+msgstr "pseudo-profile"
 
 #: /1080i/Custom_1195_SkinUserLoginScreen.xml
 msgctxt "#31508"
 msgid "Loading skin user profiles"
-msgstr ""
+msgstr "Ładowanie profili"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31509"
 msgid "Holiday"
-msgstr ""
+msgstr "Święta"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31510"
 msgid "Holiday themes"
-msgstr ""
+msgstr "Motywy świąteczne"
 
 #: /1080i/Custom_1115_Dialog_Shortcuts.xml
 msgctxt "#31511"
 msgid "Shortcut"
-msgstr ""
+msgstr "Skrót"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31515"
 msgid "Main Items"
-msgstr ""
+msgstr "Główne elementy"
 
 #: /1080i/Custom_1115_Dialog_Shortcuts.xml
 msgctxt "#31516"
 msgid "Edit items"
-msgstr ""
+msgstr "Edytuj elementy"
 
 #: /1080i/Custom_1115_Dialog_Shortcuts.xml
 msgctxt "#31517"
 msgid "Reverse order"
-msgstr ""
+msgstr "Odwróć kolejność"
 
 #: /1080i/Includes_SkinSettings.xml
 msgctxt "#31519"
 msgid "Empty widget placeholder"
-msgstr ""
+msgstr "Pusty widżet"
 
 #: /1080i/Includes_Weather_Radar.xml
 msgctxt "#31520"
 msgid "Cloudiness"
-msgstr ""
+msgstr "Zachmurzenie"
 
 #: /1080i/Includes_SkinSettings.xml
 msgctxt "#31522"
 msgid "Hiding empty widgets may cause positioning issues after video playback."
-msgstr ""
+msgstr "Zaleca się usunięcie nieużywanych widżetów zamiast ich ukrywania."
 
 #: /1080i/Includes_SkinSettings.xml
 msgctxt "#31523"
 msgid "It is recommended to delete any unused widgets from your configuration instead of hiding them."
-msgstr ""
+msgstr "po zakończeniu odtwarzania oraz dodatkowo obciąża system przy każdym odświeżaniu."
 
 #: /1080i/Includes_SkinSettings.xml
 msgctxt "#31524"
 msgid "There is also an overhead refresh cost to performance associated with hiding empty widgets."
-msgstr ""
+msgstr "Ukrywanie pustych widżetów może powodować błędy w pozycjonowaniu elementów"
 
 #: /1080i/Includes_Weather_Radar.xml
 msgctxt "#31525"
 msgid "Visibility"
-msgstr ""
+msgstr "Widoczność"
 
 #: /1080i/Includes_Weather_Forecast.xml
 msgctxt "#31526"
 msgid "Hour"
-msgstr ""
+msgstr "Godzina"
 
 #: /1080i/Includes_Weather_Forecast.xml
 msgctxt "#31527"
 msgid "Later"
-msgstr ""
+msgstr "Później"
 
 #: /1080i/Includes_Weather_Forecast.xml
 msgctxt "#31528"
 msgid "Particulate"
-msgstr ""
+msgstr "Cząstki stałe"
 
 #: /1080i/Includes_Weather_Forecast.xml
 msgctxt "#31529"
 msgid "Ozone"
-msgstr ""
+msgstr "Ozon"
 
 #: /1080i/Includes_Weather_Forecast.xml
 msgctxt "#31530"
 msgid "Solar radiation"
-msgstr ""
+msgstr "Promieniowanie słoneczne"
 
 #: /1080i/Includes_Weather_Forecast.xml
 msgctxt "#31531"
 msgid "Carbon monoxide"
-msgstr ""
+msgstr "Tlenek węgla"
 
 #: /1080i/Custom_1115_Dialog_Shortcuts.xml
 msgctxt "#31533"
 msgid "Add list"
-msgstr ""
+msgstr "Dodaj listę"
 
 #: /1080i/Custom_1115_Dialog_Shortcuts.xml
 msgctxt "#31535"
 msgid "Restore"
-msgstr ""
+msgstr "Przywróć"
 
 #: /1080i/Custom_1115_Dialog_Shortcuts.xml
 msgctxt "#31536"
 msgid "Choose fallback image folder"
-msgstr ""
+msgstr "Wybierz folder grafik rezerwowych"
 
 #: /1080i/Custom_1115_Dialog_Shortcuts.xml
 msgctxt "#31537"
 msgid "Edit submenu items"
-msgstr ""
+msgstr "Edytuj elementy podmenu"
 
 #: /1080i/Includes_SkinSettings.xml
 msgctxt "#31538"
 msgid "Customise viewtypes"
-msgstr ""
+msgstr "Typy widoków"
 
 #: /1080i/Includes_Items.xml
 msgctxt "#31539"
 msgid "Use online gallery"
-msgstr ""
+msgstr "Używaj galerii online"
 
 #: /1080i/Includes_Items.xml
 msgctxt "#31540"
 msgid "Use online collection"
-msgstr ""
+msgstr "Używaj kolekcji online"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31541"
 msgid "Next episode"
-msgstr ""
+msgstr "Następny odcinek"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31542"
 msgid "Last episode"
-msgstr ""
+msgstr "Ostatni odcinek"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31543"
 msgid "Anticipated"
-msgstr ""
+msgstr "W produkcji"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31544"
 msgid "Airing"
-msgstr ""
+msgstr "Nowy odcinek"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31545"
 msgid "Premiering"
-msgstr ""
+msgstr "Nowość"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31547"
 msgid "Yesterday"
-msgstr ""
+msgstr "Wczoraj"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31550"
 msgid "Change the visibility level of skin settings."
-msgstr ""
+msgstr "Poziom zaawansowania ustawień:"
 
 #: /1080i/Includes_SkinSettings.xml
 msgctxt "#31552"
 msgid "Settings level"
-msgstr ""
+msgstr "Poziom ustawień"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31554"
 msgid "Wall Poster"
-msgstr ""
+msgstr "Siatka: Plakaty"
 
 #: /1080i/Includes_Views_Wall.xml
 msgctxt "#31555"
 msgid "Wall Landscape"
-msgstr ""
+msgstr "Siatka: Banery"
 
 #: /1080i/Includes_Views_Wall.xml
 msgctxt "#31556"
 msgid "Wall Square"
-msgstr ""
+msgstr "Siatka: Kwadraty"
 
 #: /1080i/Includes_Views_Wall.xml
 msgctxt "#31557"
 msgid "Wall Circle"
-msgstr ""
+msgstr "Siatka: Disc Art"
 
 #: /1080i/Includes_Items.xml
 msgctxt "#31560"
 msgid "Bright White"
-msgstr ""
+msgstr "Jaskrawa biel"
 
 #: /1080i/Includes_Views_Row.xml
 msgctxt "#31563"
 msgid "Row Card"
-msgstr ""
+msgstr "Karuzela: Plakato-banery"
 
 #: /1080i/Includes_SkinSettings.xml
 msgctxt "#31564"
 msgid "General appearance and widget layout customisations."
-msgstr ""
+msgstr "Wygląd i układ widżetów."
 
 #: /1080i/Includes_SkinSettings.xml
 msgctxt "#31565"
 msgid "Detailed adjustments and additional hub customisations."
-msgstr ""
+msgstr "Szczegółowe ustawienia i dodatkowa personalizacja hubów."
 
 #: /1080i/Includes_SkinSettings.xml
 msgctxt "#31566"
 msgid "Development tools and experimental options."
-msgstr ""
+msgstr "Narzędzia deweloperskie i opcje eksperymentalne."
 
 #: /1080i/Custom_1116_Dialog_Shortcuts.xml
 msgctxt "#31567"
 msgid "Add a single item or a list of several items?"
-msgstr ""
+msgstr "Dodać pojedynczy element czy listę?"
 
 #: /1080i/Custom_1116_Dialog_Shortcuts.xml
 msgctxt "#31568"
 msgid "Add new item(s)"
-msgstr ""
+msgstr "Dodaj element(y)"
 
 #: /1080i/Custom_1116_Dialog_Shortcuts.xml
 msgctxt "#31569"
 msgid "Add item"
-msgstr ""
+msgstr "Dodaj element"
 
 #: /1080i/Custom_1116_Dialog_Shortcuts.xml
 msgctxt "#31570"
 msgid "Delete item(s)"
-msgstr ""
+msgstr "Usuń element(y)"
 
 #: /1080i/Custom_1116_Dialog_Shortcuts.xml
 msgctxt "#31571"
 msgid "Delete a single item or a list of several items?"
-msgstr ""
+msgstr "Usunąć pojedynczy element czy całą listę?"
 
 #: /1080i/Custom_1116_Dialog_Shortcuts.xml
 msgctxt "#31572"
 msgid "Delete item"
-msgstr ""
+msgstr "Usuń element"
 
 #: /1080i/Custom_1116_Dialog_Shortcuts.xml
 msgctxt "#31573"
 msgid "Delete list"
-msgstr ""
+msgstr "Usuń listę"
 
 #: /1080i/Includes_SkinSettings.xml
 msgctxt "#31576"
 msgid "Seekbar delayed pause time"
-msgstr ""
+msgstr "Pasek postępu: Opóźnienie akcji pauzy"
 
 #: /1080i/Includes_ButtonMenu.xml
 msgctxt "#31579"
 msgid "Prev"
-msgstr ""
+msgstr "Poprzedni"
 
 #: /1080i/Includes_Views_List.xml
 msgctxt "#31580"
 msgid "Combined List"
-msgstr ""
+msgstr "Lista połączona"
 
 #: /1080i/Includes_Views_List.xml
 msgctxt "#31581"
 msgid "List Expanded"
-msgstr ""
+msgstr "Lista szczegółowa: Plakaty"
 
 #: /1080i/Custom_1116_Dialog_Shortcuts.xml
 msgctxt "#31583"
 msgid "Prevent reload"
-msgstr ""
+msgstr "Zapobiegaj odświeżaniu"
 
 #: /1080i/Includes_Items.xml
 msgctxt "#31585"
 msgid "Overlay"
-msgstr ""
+msgstr "Nakładka"
 
 #: /1080i/Includes_SkinSettings.xml
 msgctxt "#31586"
 msgid "Customise shortcuts"
-msgstr ""
+msgstr "Skróty"
 
 #: /1080i/Includes_OSD.xml
 msgctxt "#31594"
 msgid "Press down"
-msgstr ""
+msgstr "Naciśnij w dół"
 
 #: /1080i/Includes_OSD.xml
 msgctxt "#31595"
 msgid "Press right"
-msgstr ""
+msgstr "Naciśnij w prawo"
 
 #: /1080i/Includes_SkinSettings.xml
 msgctxt "#31596"
 msgid "Additional icons"
-msgstr ""
+msgstr "Więcej ruchomych elementów"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31597"
 msgid "Confirmation"
-msgstr ""
+msgstr "Potwierdzenie"
 
 #: /1080i/Dialogs_DialogGameControllers.xml
 msgctxt "#31598"
 msgid "Controllers"
-msgstr ""
+msgstr "Kontrolery"
 
 #: /1080i/Dialogs_DialogPVRGroupManager.xml
 msgctxt "#31599"
 msgid "Ungrouped"
-msgstr ""
+msgstr "Niezgrupowane"
 
 #: /1080i/Includes_Info.xml
 msgctxt "#31600"
 msgid "Ends at"
-msgstr ""
+msgstr "Seans do"
 
 #: /1080i/Custom_1115_Window_Shortcuts.xml
 msgctxt "#31601"
 msgid "Edit tray"
-msgstr ""
+msgstr "Edytuj zasobnik"
 
 #: /1080i/Dialog_DialogContextMenu.xml
 msgctxt "#31602"
 msgid "Add shortcut"
-msgstr ""
+msgstr "Dodaj jako skrót"
 
 #: /1080i/Includes_SkinSettings.xml
 msgctxt "#31604"
 msgid "Additional"
-msgstr ""
+msgstr "Dodatkowe"
 
 #: /1080i/Includes_SkinSettings.xml
 msgctxt "#31605"
 msgid "Next aired"
-msgstr ""
+msgstr "Harmonogram premier"


### PR DESCRIPTION
In this MR:
* Added Polish translation 
* Fixed incorrect context for "Label": replaced built-in string 21899 (music record label) with newly added string 31273.
* Kept 21899 intact only where it actually refers to a music label.