### PR TITLE
🐛 Set max width for Spotlight button to prevent clipping - Resolves #265

### DIFF
--- a/1080i/Includes_Hubs.xml
+++ b/1080i/Includes_Hubs.xml
@@ -399,7 +399,7 @@
                 </control>
             </control>
             <control type="button" id="$PARAM[id]">
-                <width>$PARAM[width]</width>
+                <width max="$PARAM[max]">$PARAM[width]</width>
                 <height>80</height>
                 <centertop>50%</centertop>
                 <textoffsetx>0</textoffsetx>
@@ -487,6 +487,7 @@
                             <param name="groupid">321</param>
                             <param name="label">$VAR[Label_FullscreenWidget_PlayButton]</param>
                             <param name="image">$VAR[Image_FullscreenWidget_PlayButton]</param>
+                            <param name="max">160</param>
                             <onclick>SetFocus(301)</onclick>
                             <onclick condition="!String.StartsWith(Container(301).ListItem.FolderPath,videodb://)">Action(select)</onclick>
                             <onclick condition="String.StartsWith(Container(301).ListItem.FolderPath,videodb://)">Action(play)</onclick>


### PR DESCRIPTION
Note: The max width of `160` is based on visual trial and error. Can be refined later with a better technical approach.