### PR TITLE
Add override for Plex Kodi Connect's Skip Marker

### DIFF
--- a/1080i/script-plex-skip_marker.xml
+++ b/1080i/script-plex-skip_marker.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<window>
+    <defaultcontrol always="true">3002</defaultcontrol>
+    <onload>Dialog.Close(fullscreeninfo,true)</onload>
+    <onload>Dialog.Close(videoosd,true)</onload>
+    
+    <animation type="WindowOpen" reversible="false">
+        <effect type="fade" start="0" end="100" time="300"/>
+    </animation>
+    <animation type="WindowClose" reversible="false">
+        <effect type="fade" start="100" end="0" time="200"/>
+    </animation>
+
+    <controls>
+        <control type="group">
+            <left>60</left>
+            <bottom>60</bottom>
+            <height>60</height>
+            <width>auto</width>
+
+            <control type="button" id="3002">
+                <width>auto</width>
+                <minwidth>180</minwidth>
+                <maxwidth>500</maxwidth>
+                <height>100%</height>
+                
+                <texturefocus border="30" colordiffuse="panel_bg_100">common/dialog.png</texturefocus>
+                <texturenofocus border="30" colordiffuse="panel_bg_70">common/dialog.png</texturenofocus>
+                
+                <label>[COLOR 00000000]     [/COLOR]$INFO[Window.Property(marker_message)]</label>
+                
+                <font>font_main_bold</font>
+                <textcolor>panel_fg_70</textcolor>
+                <focusedcolor>$VAR[ColorSelected]</focusedcolor>
+                
+                <align>left</align>
+                <aligny>center</aligny>
+                
+                <textoffsetx>20</textoffsetx>
+            </control>
+
+            <control type="image">
+                <left>0</left>
+                <centertop>50%</centertop>
+                <width>60</width>
+                <height>60</height>
+                <texture colordiffuse="panel_fg_70">special://skin/extras/icons/forward-step.png</texture>
+                <visible>!Control.HasFocus(3002)</visible>
+            </control>
+
+            <control type="image">
+                <left>0</left>
+                <centertop>50%</centertop>
+                <width>60</width>
+                <height>60</height>
+                <texture colordiffuse="$VAR[ColorSelected]">special://skin/extras/icons/forward-step.png</texture>
+                <visible>Control.HasFocus(3002)</visible>
+            </control>
+        </control>
+    </controls>
+</window>

--- a/1080i/script-plex-skip_marker.xml
+++ b/1080i/script-plex-skip_marker.xml
@@ -4,12 +4,8 @@
     <onload>Dialog.Close(fullscreeninfo,true)</onload>
     <onload>Dialog.Close(videoosd,true)</onload>
     
-    <animation type="WindowOpen" reversible="false">
-        <effect type="fade" start="0" end="100" time="300"/>
-    </animation>
-    <animation type="WindowClose" reversible="false">
-        <effect type="fade" start="100" end="0" time="200"/>
-    </animation>
+    <include>Animation_FadeIn</include>
+    <include>Animation_FadeOut</include>
 
     <controls>
         <control type="group">


### PR DESCRIPTION
This dialog appears when an option is available to Skip intro, Skip commercials, or Skip credits. The button is dynamically sized to accommodate any text length (for e.g. translations).

<img width="1920" height="1080" alt="screenshot00000" src="https://github.com/user-attachments/assets/91458ebf-686a-416f-92f8-2b7bb0f70093" />
<img width="1920" height="1080" alt="screenshot00002" src="https://github.com/user-attachments/assets/bbe85c82-921a-43cf-bfd3-bce265bd3bdb" />
