### PR TITLE
⚡ Override Startup previouswindow to Home

### DIFF
--- a/1080i/Startup.xml
+++ b/1080i/Startup.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
+    <previouswindow>Home</previouswindow>
     <onload condition="Skin.HasSetting(SkinUserLogin.StartupLoginScreen) + !Skin.HasSetting(SkinUserLogin.Disabled) + String.IsEmpty(Window(Home).Property(StartupReplaceWindow))">SetProperty(StartupReplaceWindow,1195,Home)</onload>
     <onload>SetProperty(SplashIsVisible,True,1198)</onload>
     <onload>AlarmClock(SplashTimeOut,noop,00:59,silent)</onload>


### PR DESCRIPTION
To avoid visual glitches when pressing back during startup routine.

---

Hey Jurial!

Hope you're doing well!

Sometimes the startup loading can take a while or get interrupted by an addon update (or "wizards" running some type of cleanup) which leads to the startup window never clearing.

Previously, on AF1/2 you could click back and it would clear the loading screen because it was a separate custom window. But on AF3 clicking back during Startup will start flashing/glitching the screen (I guess since the window history is empty and there is no window to go back to).

You can recreate this if you use some kind of online widget path as your first widget (so it takes a longer time to load than a local widget) and click back quickly after startup.

This PR simply forces a `<previouswindow>` to deal with these edge cases.

---

On a different note, I wasn't sure if you'd see a comment on a merged PR https://github.com/jurialmunkey/skin.arctic.fuse.3/commit/9383f45e6c8b3c5d6d5259430931d6098fb84a9e so thought I'd say it here.

Is there a reason to use a separate json script file to achieve this? Wouldn't something like this also work?
``` 
RunScript(script.skinvariables,run_executebuiltin=Action(Stop)||sleep=0.5||PlayMedia($ESCINFO[Container(450).ListItem.FileNameAndPath]))
```

I might be completely off the mark but just wanted to make sure haha.

Thanks!
