### PR TITLE
⚡ Add tmdb id for more accurate recommendations

### DIFF
--- a/1080i/Includes_Lists.xml
+++ b/1080i/Includes_Lists.xml
@@ -756,6 +756,8 @@
             <onfocus condition="$PARAM[condition]">SetProperty(WidgetMeta.$PARAM[id].Year,$ESCINFO[$PARAM[container]ListItem.Year])</onfocus>
             <onfocus condition="$PARAM[condition]">SetProperty(WidgetMeta.$PARAM[id].Studio,$ESCINFO[$PARAM[container]ListItem.Studio])</onfocus>
             <onfocus condition="$PARAM[condition]">SetProperty(WidgetMeta.$PARAM[id].FolderPath,$ESCINFO[$PARAM[container]ListItem.FolderPath])</onfocus>
+            <onfocus condition="$PARAM[condition] + !String.IsEqual($PARAM[container]ListItem.DBType,episode)">SetProperty(WidgetMeta.$PARAM[id].TMDb_ID,$ESCINFO[$PARAM[container]ListItem.UniqueID(tmdb)])</onfocus>
+            <onfocus condition="$PARAM[condition] + String.IsEqual($PARAM[container]ListItem.DBType,episode)">ClearProperty(WidgetMeta.$PARAM[id].TMDb_ID)</onfocus>
 
             <onfocus condition="$PARAM[condition] + [String.IsEqual($PARAM[container]ListItem.DBType,artist) | String.IsEqual($PARAM[container]ListItem.DBType,album) | String.IsEqual($PARAM[container]ListItem.DBType,song)]">SetProperty(WidgetMeta.$PARAM[id].Target,music)</onfocus>
             <onfocus condition="$PARAM[condition] + ![String.IsEqual($PARAM[container]ListItem.DBType,artist) | String.IsEqual($PARAM[container]ListItem.DBType,album) | String.IsEqual($PARAM[container]ListItem.DBType,song)]">SetProperty(WidgetMeta.$PARAM[id].Target,videos)</onfocus>

--- a/shortcuts/generator/data/setup/widgets_row.xml
+++ b/shortcuts/generator/data/setup/widgets_row.xml
@@ -67,11 +67,11 @@
         </rule>
         <rule>
             <condition>{item_path}==Stacked_Movie_Recommendations</condition>
-            <value>plugin://plugin.video.themoviedb.helper/?info=recommendations&amp;nextpage=false&amp;cacheonly=true&amp;length=1&amp;amp;tmdb_type=movie&amp;amp;query=$INFO[Window.Property(WidgetMeta.{widget_prev_id}.Title)]</value>
+            <value>plugin://plugin.video.themoviedb.helper/?info=recommendations&amp;nextpage=false&amp;cacheonly=true&amp;length=1&amp;amp;tmdb_type=movie&amp;amp;query=$INFO[Window.Property(WidgetMeta.{widget_prev_id}.Title)]$INFO[Window.Property(WidgetMeta.{widget_prev_id}.TMDb_ID),&amp;amp;tmdb_id=,]</value>
         </rule>
         <rule>
             <condition>{item_path}==Stacked_TVShows_Recommendations</condition>
-            <value>plugin://plugin.video.themoviedb.helper/?info=recommendations&amp;nextpage=false&amp;cacheonly=true&amp;length=1&amp;amp;tmdb_type=tv&amp;amp;query=$INFO[Window.Property(WidgetMeta.{widget_prev_id}.TvShowTitle)]</value>
+            <value>plugin://plugin.video.themoviedb.helper/?info=recommendations&amp;nextpage=false&amp;cacheonly=true&amp;length=1&amp;amp;tmdb_type=tv&amp;amp;query=$INFO[Window.Property(WidgetMeta.{widget_prev_id}.TvShowTitle)]$INFO[Window.Property(WidgetMeta.{widget_prev_id}.TMDb_ID),&amp;amp;tmdb_id=,]</value>
         </rule>
         <rule>
             <condition>{item_path}==Stacked_Movie_Year</condition>


### PR DESCRIPTION
Should hopefully resolve #312 

I haven't had the chance to extensively test it but should theoretically prioritize tmd_id over title lookup

Was also going to add tvshow.tmdb_id but noticed `ListItem.UniqueID(tvshow.tmdb)` only seems to be filled by episodes from TMDb Helper.
Most other addons display the tvshow.tmdb_id in the tmdb_id field for episodes (and I think there's no tmdb_id for episodes either way) so just reused that for TV Show recommendations as well.