### PR TITLE
Fix PVR and TMDbHelper artwork handling

### DIFF
--- a/1080i/Includes_Images.xml
+++ b/1080i/Includes_Images.xml
@@ -264,6 +264,9 @@
 
     <variable name="Image_Foreground_NoService">
         <value condition="!String.IsEmpty(Container.ListItem.Art(fanart))">$INFO[Container.ListItem.Art(fanart)]</value>
+        <value condition="!String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.Fanart))">$INFO[Window(Home).Property(TMDbHelper.ListItem.Fanart)]</value>
+        <value condition="!String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.tvshow.fanart))">$INFO[Window(Home).Property(TMDbHelper.ListItem.tvshow.fanart)]</value>
+        <value condition="!String.IsEmpty(Container.ListItem.EPGEventIcon) + !String.IsEqual(Container.ListItem.Icon,Container.ListItem.EPGEventIcon)">$INFO[Container.ListItem.EPGEventIcon]</value>
         <value condition="Integer.IsEqual(Window.Property(TMDbHelper.WidgetContainer),301)">$INFO[Container(301).ListItem.Art(fanart)]</value>
         <value condition="Integer.IsEqual(Window.Property(TMDbHelper.WidgetContainer),501)">$INFO[Container(501).ListItem.Art(fanart)]</value>
         <value condition="Integer.IsEqual(Window.Property(TMDbHelper.WidgetContainer),502)">$INFO[Container(502).ListItem.Art(fanart)]</value>


### PR DESCRIPTION
Fixes #327

## What does this PR do?

Fixes the no fanart when blur is disabled bug. It adds TMDbHelper fanart and TV-show fanart as additional artwork sources for Live TV items while retaining the existing PVR EPG artwork fallback.

This allows:

- PVR-supplied artwork to remain available for programs without a TMDb match.
- TMDbHelper fanart to be displayed when available.
- TMDbHelper TV-show fanart to be used when available.
- PVR EPG artwork to continue providing a fallback for unmatched programs.

## Testing

Tested with PVR Live TV items in Arctic Fuse 3.

Confirmed that:
- TMDbHelper artwork is displayed for matched programs.
- PVR-supplied artwork remains available for unmatched programs.
- The change requires only three additions to `1080i/Includes_Images.xml`.
- No other files were modified.