### PR TITLE
Fix incorrect Home layout after skin startup/reload

### DIFF
--- a/1080i/Home.xml
+++ b/1080i/Home.xml
@@ -18,7 +18,7 @@
 
     <onload>$VAR[Action_RatingsMonitor]</onload>
 
-    <onload condition="Skin.HasSetting(Home.FirstRun) + String.IsEmpty(Window(1198).Property(FirstStart))">$VAR[Action_FirstStart_HomeFocus]</onload>
+    <onload condition="Skin.HasSetting(Home.FirstRun) + String.IsEmpty(Window(1198).Property(FirstStart))">RunScript(script.skinvariables,run_executebuiltin=special://skin/shortcuts/skinvariables-homefocus.json,use_rules=True)</onload>
     <onload condition="Skin.HasSetting(Home.FirstRun) + String.IsEmpty(Window(1198).Property(FirstStart))">SetProperty(FirstStart,True,1198)</onload>
 
     <controls>

--- a/shortcuts/skinvariables-homefocus.json
+++ b/shortcuts/skinvariables-homefocus.json
@@ -40,7 +40,18 @@
         ]
     },
     "actions": [
-        "sleep=0.3",
-        "{InitialHomeFocus}"
+        "sleep=0.5",
+        {
+            "rules": ["!Skin.HasSetting(HomeSwitcher.Vertical)"],
+            "value": [
+                "SetFocus(300)",
+                "sleep=0.15",
+                "Action(Down)"
+            ]
+        },
+        {
+            "rules": ["Skin.HasSetting(HomeSwitcher.Vertical)"],
+            "value": "{InitialHomeFocus}"
+        }
     ]
 }

--- a/shortcuts/skinvariables-homefocus.json
+++ b/shortcuts/skinvariables-homefocus.json
@@ -1,0 +1,46 @@
+{
+    "values": {
+        "InitialHomeFocus": [
+            {
+                "rules": ["Skin.HasSetting(HomeSwitcher.DisableFirstWidgetFocus)"],
+                "value": "SetFocus(300)"
+            },
+            {
+                "rules": ["!String.IsEmpty(Skin.String(HomeSwitcher.Home.Spotlight.Target))"],
+                "value": "SetFocus(310)"
+            },
+            {
+                "rules": [
+                    "!String.IsEmpty(Skin.String(HomeSwitcher.Home.Mode))",
+                    "Control.IsVisible(601)"
+                ],
+                "value": "SetFocus(601)"
+            },
+            {
+                "rules": ["Control.IsVisible(501)"],
+                "value": "SetFocus(501)"
+            },
+            {
+                "rules": ["Control.IsVisible(502)"],
+                "value": "SetFocus(502)"
+            },
+            {
+                "rules": ["Control.IsVisible(503)"],
+                "value": "SetFocus(503)"
+            },
+            {
+                "rules": ["Control.IsVisible(504)"],
+                "value": "SetFocus(504)"
+            },
+            {
+                "rules": ["Control.IsVisible(505)"],
+                "value": "SetFocus(505)"
+            },
+            "SetFocus(300)"
+        ]
+    },
+    "actions": [
+        "sleep=0.3",
+        "{InitialHomeFocus}"
+    ]
+}


### PR DESCRIPTION
The issue reproduces on Apple TV and Nvidia Shield TV Pro, but not on macOS.  The Home screen can load with widgets pushed to the bottom and the Top menu hidden (see screenshot below); it remains stuck until you press the Down button, which resolves it. Reproducing that same focus/navigation transition during Home initialization fixes the problem.

This fix was tested successfully on AppleTV, Nvidia Shield TV Pro, and Mac.  The incorrect layout no longer occurs after startup/reload.

<img width="1280" height="720" alt="IMG_0583" src="https://github.com/user-attachments/assets/89923ad0-53c8-45ca-b48d-9ce0c889c4b9" />
