### PR TITLE
feat: theme jellyfin skip segment buttons

### DIFF
--- a/1080i/Includes_Images.xml
+++ b/1080i/Includes_Images.xml
@@ -409,12 +409,12 @@
 
     <variable name="Image_JellyfinSkip">
         <value condition="!String.IsEmpty(Window.Property(segment_image))">$INFO[Window.Property(segment_image)]</value>
-        <value condition="!String.IsEmpty(Player.Art(season.poster))">$INFO[Player.Art(season.poster)]</value>
-        <value condition="!String.IsEmpty(Player.Art(tvshow.poster))">$INFO[Player.Art(tvshow.poster)]</value>
-        <value condition="!String.IsEmpty(Player.Art(season.landscape))">$INFO[Player.Art(season.landscape)]</value>
-        <value condition="!String.IsEmpty(Player.Art(tvshow.landscape))">$INFO[Player.Art(tvshow.landscape)]</value>
-        <value condition="!String.IsEmpty(Player.Art(tvshow.fanart))">$INFO[Player.Art(tvshow.fanart)]</value>
-        <value>$INFO[Player.Art(thumb)]</value>
+		<value condition="!String.IsEmpty(Player.Art(thumb))">$INFO[Player.Art(thumb)]</value>
+		<value condition="!String.IsEmpty(Player.Art(season.landscape))">$INFO[Player.Art(season.landscape)]</value>
+		<value condition="!String.IsEmpty(Player.Art(tvshow.landscape))">$INFO[Player.Art(tvshow.landscape)]</value>
+		<value condition="!String.IsEmpty(Player.Art(season.poster))">$INFO[Player.Art(season.poster)]</value>
+		<value condition="!String.IsEmpty(Player.Art(tvshow.poster))">$INFO[Player.Art(tvshow.poster)]</value>
+		<value condition="!String.IsEmpty(Player.Art(tvshow.fanart))">$INFO[Player.Art(tvshow.fanart)]</value>
     </variable>
 
     <variable name="Image_IsCurrentStream">

--- a/1080i/Includes_Images.xml
+++ b/1080i/Includes_Images.xml
@@ -408,7 +408,7 @@
     </variable>
 
     <variable name="Image_JellyfinSkip">
-        <value condition="!String.IsEmpty(Window.Property(trickplay_image))">$INFO[Window.Property(trickplay_image)]</value>
+        <value condition="!String.IsEmpty(Window.Property(segment_image))">$INFO[Window.Property(segment_image)]</value>
         <value>$INFO[Player.Art(thumb)]</value>
     </variable>
 

--- a/1080i/Includes_Images.xml
+++ b/1080i/Includes_Images.xml
@@ -409,6 +409,11 @@
 
     <variable name="Image_JellyfinSkip">
         <value condition="!String.IsEmpty(Window.Property(segment_image))">$INFO[Window.Property(segment_image)]</value>
+        <value condition="!String.IsEmpty(Player.Art(season.poster))">$INFO[Player.Art(season.poster)]</value>
+        <value condition="!String.IsEmpty(Player.Art(tvshow.poster))">$INFO[Player.Art(tvshow.poster)]</value>
+        <value condition="!String.IsEmpty(Player.Art(season.landscape))">$INFO[Player.Art(season.landscape)]</value>
+        <value condition="!String.IsEmpty(Player.Art(tvshow.landscape))">$INFO[Player.Art(tvshow.landscape)]</value>
+        <value condition="!String.IsEmpty(Player.Art(tvshow.fanart))">$INFO[Player.Art(tvshow.fanart)]</value>
         <value>$INFO[Player.Art(thumb)]</value>
     </variable>
 

--- a/1080i/Includes_Images.xml
+++ b/1080i/Includes_Images.xml
@@ -407,6 +407,11 @@
         <value condition="!String.IsEmpty(Window.Property(thumb))">$INFO[Window.Property(thumb)]</value>
     </variable>
 
+    <variable name="Image_JellyfinSkip">
+        <value condition="!String.IsEmpty(Window.Property(trickplay_image))">$INFO[Window.Property(trickplay_image)]</value>
+        <value>$INFO[Player.Art(thumb)]</value>
+    </variable>
+
     <variable name="Image_IsCurrentStream">
         <value condition="!String.IsEmpty(ListItem.Property(iscurrent))">buttons/check-on.png</value>
         <value>buttons/check-off.png</value>

--- a/1080i/Includes_OSD.xml
+++ b/1080i/Includes_OSD.xml
@@ -2,6 +2,10 @@
 <includes>
 
     <include name="OSD_UpNext_Buttons">
+        <param name="primary_label">$LOCALIZE[208]</param>
+        <param name="close_id">4013</param>
+        <param name="close_proxy">true</param>
+        <definition>
 
         <control type="grouplist" id="4000">
             <top>300</top>
@@ -17,7 +21,7 @@
                 <param name="icon">special://skin/extras/icons/play2.png</param>
                 <param name="id">3012</param>
                 <param name="groupid">5012</param>
-                <param name="label">$LOCALIZE[208]</param>
+                <param name="label">$PARAM[primary_label]</param>
                 <param name="include_hintlabel">true</param>
             </include>
 
@@ -29,14 +33,15 @@
             <include content="DialogInfo_Button">
                 <param name="vertical">false</param>
                 <param name="icon">special://skin/extras/icons/xmark.png</param>
-                <param name="id">4013</param>
+                <param name="id">$PARAM[close_id]</param>
                 <param name="groupid">5013</param>
                 <param name="label">$LOCALIZE[222]</param>
                 <param name="include_hintlabel">true</param>
-                <onclick>SetFocus(3013)</onclick>
-                <onclick>Action(Select)</onclick>
+                <onclick condition="$PARAM[close_proxy]">SetFocus(3013)</onclick>
+                <onclick condition="$PARAM[close_proxy]">Action(Select)</onclick>
             </include>
         </control>
+        </definition>
     </include>
 
     <include name="OSD_UpNext_Progress">
@@ -196,6 +201,17 @@
                 <param name="id">3013</param>
             </include>
         </definition>
+    </include>
+
+    <include name="OSD_JellyfinSkip_Buttons">
+        <control type="group">
+            <include>OSD_Info_Dimensions</include>
+            <include content="OSD_UpNext_Buttons">
+                <param name="primary_label">$INFO[Window.Property(skip_label)]</param>
+                <param name="close_id">3013</param>
+                <param name="close_proxy">false</param>
+            </include>
+        </control>
     </include>
 
 
@@ -1251,5 +1267,3 @@
         </definition>
     </include>
 </includes>
-
-

--- a/1080i/script-jellyfin-skip.xml
+++ b/1080i/script-jellyfin-skip.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Arctic Fuse presentation for Jellyfin-Kodi's native media-segment dialog. -->
+<window>
+    <defaultcontrol always="true">3012</defaultcontrol>
+    <onload>Dialog.Close(fullscreeninfo,true)</onload>
+    <onload>Dialog.Close(videoosd,true)</onload>
+    <include>Animation_FadeIn</include>
+    <controls>
+        <include content="OSD_UpNext">
+            <param name="is_addon">false</param>
+            <param name="icon">$VAR[Image_OSD_Landscape]</param>
+            <param name="label">$INFO[Window.Property(skip_label)]</param>
+            <param name="secondary_label"></param>
+            <param name="top_title">$INFO[VideoPlayer.Title]</param>
+            <param name="sub_title">$INFO[VideoPlayer.TVShowTitle]</param>
+        </include>
+
+        <include>OSD_JellyfinSkip_Buttons</include>
+    </controls>
+</window>

--- a/1080i/script-jellyfin-skip.xml
+++ b/1080i/script-jellyfin-skip.xml
@@ -8,7 +8,7 @@
     <controls>
         <include content="OSD_UpNext">
             <param name="is_addon">false</param>
-            <param name="icon">$INFO[Player.Art(thumb)]</param>
+            <param name="icon">$VAR[Image_JellyfinSkip]</param>
             <param name="label">$INFO[Window.Property(skip_label)]</param>
             <param name="secondary_label"></param>
             <param name="top_title">$INFO[VideoPlayer.Title]</param>

--- a/1080i/script-jellyfin-skip.xml
+++ b/1080i/script-jellyfin-skip.xml
@@ -8,7 +8,7 @@
     <controls>
         <include content="OSD_UpNext">
             <param name="is_addon">false</param>
-            <param name="icon">$VAR[Image_OSD_Landscape]</param>
+            <param name="icon">$INFO[Player.Art(thumb)]</param>
             <param name="label">$INFO[Window.Property(skip_label)]</param>
             <param name="secondary_label"></param>
             <param name="top_title">$INFO[VideoPlayer.Title]</param>


### PR DESCRIPTION
Jellyfin Kodi add-on can optionally show a button to skip the segment (intro/outro/commercial/recap) when it is detected by the server. This PR themes that button to follow the same structure as the `upnext` button with a few caveats.

A related PR jellyfin/jellyfin-kodi#1179 exists to include trickplay (timed episode thumbnails) but it is not necessary for that PR to be merged since this PR falls back to other images if `segment_image` is not available.