### PR TITLE
Prevent AutoOnPause OSD Details from appearing over Video Info

### DIFF
--- a/1080i/Includes_Expressions.xml
+++ b/1080i/Includes_Expressions.xml
@@ -128,7 +128,7 @@
 
     <expression name="Exp_OSD_DelayInfo_Timing">[[System.IdleTime(3)] | [System.IdleTime(2) + Skin.String(OSD.AutoOnPause.Delay,2s)] | [System.IdleTime(1) + Skin.String(OSD.AutoOnPause.Delay,1s)] | [System.IdleTime(0) + Skin.String(OSD.AutoOnPause.Delay,0s)]]</expression>
 
-    <expression name="Exp_OSD_DelayInfo">[$EXP[Exp_OSD_DelayInfo_Timing] + Skin.String(OSD.AutoOnPause,Info) + Player.Paused]</expression>
+    <expression name="Exp_OSD_DelayInfo">[$EXP[Exp_OSD_DelayInfo_Timing] + Skin.String(OSD.AutoOnPause,Info) + Player.Paused + !$EXP[Exp_InfoDialogs]]</expression>
 
     <expression name="Exp_OSD_QuickInfo">[$EXP[Exp_OSD_PVRChannelSwitch] | Window.IsActive(fullscreeninfo) | $EXP[Exp_OSD_DelayInfo]]</expression>
 


### PR DESCRIPTION
## Description 
 
When OSD.AutoOnPause is configured to show Info after a delay, the OSD Details can appear again while the video is paused and the user is already viewing the Video Info page. 
 
### Steps to reproduce 
 
1. Pause a video. 
2. Open the Video Info / Details page. 
3. Leave the player idle without any input. 
4. Wait until the configured OSD.AutoOnPause.Delay expires. 
 
### Current behaviour 
 
The delayed AutoOnPause logic is triggered even though the Video Info page is already open, causing the OSD Details to appear on top of the existing Info page. 
 
This results in two UI layers being displayed at the same time. 
 
### Expected behaviour 
 
When a Video Info page is already open, the delayed OSD.AutoOnPause Info action should not be triggered again. 
 
The automatic OSD Details behaviour should otherwise remain unchanged. 
 
### Fix 
 
Update Exp_OSD_DelayInfo so that the delayed Info OSD is only triggered when no Info dialog is currently open. 
 
```diff 
- <expression name="Exp_OSD_DelayInfo">[$EXP[Exp_OSD_DelayInfo_Timing] + Skin.String(OSD.AutoOnPause,Info) + Player.Paused]</expression> 
+ <expression name="Exp_OSD_DelayInfo">[$EXP[Exp_OSD_DelayInfo_Timing] + Skin.String(OSD.AutoOnPause,Info) + Player.Paused + !$EXP[Exp_InfoDialogs]]</expression>