### PR TITLE
Fix YouTube video title selection without changing music metadata

### DIFF
--- a/1080i/Includes_Images.xml
+++ b/1080i/Includes_Images.xml
@@ -134,6 +134,7 @@
         <value condition="!String.IsEmpty(VideoPlayer.Art(tvshow.landscape))">$INFO[VideoPlayer.Art(tvshow.landscape)]</value>
         <value condition="!String.IsEmpty(Player.Art(landscape))">$INFO[Player.Art(landscape)]</value>
         <value condition="!String.IsEmpty(Player.Art(tvshow.landscape))">$INFO[Player.Art(tvshow.landscape)]</value>
+        <value condition="String.IsEmpty(VideoPlayer.DBID) + !String.IsEmpty(Player.Art(thumb))">$INFO[Player.Art(thumb)]</value>
         <value condition="!String.IsEmpty(VideoPlayer.Art(fanart))">$INFO[VideoPlayer.Art(fanart)]</value>
         <value condition="!String.IsEmpty(VideoPlayer.Art(tvshow.fanart))">$INFO[VideoPlayer.Art(tvshow.fanart)]</value>
         <value condition="!String.IsEmpty(Player.Art(fanart))">$INFO[Player.Art(fanart)]</value>

--- a/1080i/Includes_Info.xml
+++ b/1080i/Includes_Info.xml
@@ -440,6 +440,7 @@
                     <visible>String.IsEmpty($PARAM[container]$PARAM[listitem].Art(tvshow.clearlogo))</visible>
                     <visible>String.IsEmpty($PARAM[container]$PARAM[listitem].Art(artist.clearlogo))</visible>
                     <visible>String.IsEmpty($PARAM[container]$PARAM[listitem].TVShowTitle)</visible>
+                    <visible>String.IsEqual($PARAM[container]$PARAM[listitem].DBType,song) | String.IsEqual($PARAM[container]$PARAM[listitem].DBType,album) | String.IsEqual($PARAM[container]$PARAM[listitem].DBType,artist) | String.IsEqual($PARAM[container]$PARAM[listitem].DBType,musicvideo)</visible>
                     <textcolor>$PARAM[colordiffuse]_100</textcolor>
                 </control>
                 <control type="label">
@@ -452,7 +453,7 @@
                     <visible>String.IsEmpty($PARAM[container]$PARAM[listitem].Art(tvshow.clearlogo))</visible>
                     <visible>String.IsEmpty($PARAM[container]$PARAM[listitem].Art(artist.clearlogo))</visible>
                     <visible>String.IsEmpty($PARAM[container]$PARAM[listitem].TVShowTitle)</visible>
-                    <visible>String.IsEmpty($PARAM[container]$PARAM[listitem].Artist)</visible>
+                    <visible>String.IsEmpty($PARAM[container]$PARAM[listitem].Artist) | ![String.IsEqual($PARAM[container]$PARAM[listitem].DBType,song) | String.IsEqual($PARAM[container]$PARAM[listitem].DBType,album) | String.IsEqual($PARAM[container]$PARAM[listitem].DBType,artist) | String.IsEqual($PARAM[container]$PARAM[listitem].DBType,musicvideo)]</visible>
                     <textcolor>$PARAM[colordiffuse]_100</textcolor>
                 </control>
                 <control type="label">
@@ -465,7 +466,7 @@
                     <visible>String.IsEmpty($PARAM[container]$PARAM[listitem].Art(tvshow.clearlogo))</visible>
                     <visible>String.IsEmpty($PARAM[container]$PARAM[listitem].Art(artist.clearlogo))</visible>
                     <visible>String.IsEmpty($PARAM[container]$PARAM[listitem].TVShowTitle)</visible>
-                    <visible>String.IsEmpty($PARAM[container]$PARAM[listitem].Artist)</visible>
+                    <visible>String.IsEmpty($PARAM[container]$PARAM[listitem].Artist) | ![String.IsEqual($PARAM[container]$PARAM[listitem].DBType,song) | String.IsEqual($PARAM[container]$PARAM[listitem].DBType,album) | String.IsEqual($PARAM[container]$PARAM[listitem].DBType,artist) | String.IsEqual($PARAM[container]$PARAM[listitem].DBType,musicvideo)]</visible>
                     <visible>String.IsEmpty($PARAM[container]$PARAM[listitem].Title)</visible>
                     <textcolor>$PARAM[colordiffuse]_100</textcolor>
                 </control>

--- a/1080i/Includes_OSD.xml
+++ b/1080i/Includes_OSD.xml
@@ -585,6 +585,7 @@
                     <param name="listitem">VideoPlayer</param>
                     <param name="service">Player</param>
                     <param name="croplogo">Window(Home).Property(TMDbHelper.Player.CropImage)</param>
+                    <param name="wrapmultiline">false</param>
                 </include>
 
                 <include content="Info_Line">


### PR DESCRIPTION
> **Revised branch, closed PR:** GitHub rejected reopening this PR. Its Files changed tab still shows the old snapshot. The tested revision is available in [this exact diff](https://github.com/Serph91P/skin.arctic.fuse.3/compare/81df380d11e8f0b02eb1dbb6db46f1123014ae92...ac6460084cf0717163a6dca03b8dc154bc471fda). The notes below describe that revision, not the frozen PR diff.

Fix the video title being replaced by the YouTube channel name in the info panel and video OSD (#328).

YouTube supplies the channel through `Artist` and the video name through `Title`. `Info_Title` currently gives `Artist` priority. The previous patch also queried `VideoPlayer.DBType`, which is not a supported player label, and changed artwork and wrapping unnecessarily.

This revision only changes title selection:
- The browsing caller opts into title-first display for `ListItem.DBType=video`. Empty DBType values keep the existing artist behaviour, including music files and music add-ons.
- The two player callers use `VideoPlayer.Content(musicvideos)` instead. The shared compact caller also preserves audio playback.
- TV-show titles, clearlogos and the label fallback keep their existing priority. Artwork and wrapping changes have been removed.

This differs from the music-type whitelist in #334: an unknown type is not treated as evidence that an item is not music.

### Verification

Tested commit `ac6460084cf0717163a6dca03b8dc154bc471fda` against `omega` at `81df380d11e8f0b02eb1dbb6db46f1123014ae92`.

- Kodi 21.2 on Linux, using an isolated profile and native XML dialogs containing the actual `Info_Title` include and its three caller configurations.
- 11 list-item fixtures and 6 playback fixtures passed. These cover generic video, missing title, empty-DBType music, songs/albums/artists, musicvideos, episodes, movies and audio playback. Playback fixtures use local generated media; they do not contact YouTube.
- The same tests reproduce four title/fallback failures on upstream; the other 13 cases pass before and after.
- All 245 tracked XML files parse; `git diff --check` passes.

These are focused Kodi component tests, not a complete skin/YouTube end-to-end test. The max-pc installation was not changed.
