### PR TITLE
Add Kodi version to System Information

### DIFF
--- a/1080i/SettingsSystemInfo.xml
+++ b/1080i/SettingsSystemInfo.xml
@@ -165,6 +165,14 @@
                                     </control>
                                 </control>
                             </control>
+                            <control type="label">
+                                <description>Kodi Version</description>
+                                <textcolor>main_fg_70</textcolor>
+                                <textoffsetx>40</textoffsetx>
+                                <height>40</height>
+                                <label>Kodi $LOCALIZE[31159]: $INFO[System.BuildVersionShort]$INFO[System.BuildVersionCode, (,)]</label>
+                                <visible>Control.HasFocus(95)</visible>
+                            </control>
                             <control type="label" id="2">
                                 <textcolor>main_fg_70</textcolor>
                                 <textoffsetx>40</textoffsetx>


### PR DESCRIPTION
Adds the running Kodi version to Information > Summary.

- Adds a dedicated localized Kodi Version row to the Summary panel
- Uses `System.BuildVersionShort` and `System.BuildVersionCode`, matching Kodi's current Estuary system-information implementation

Tested locally on macOS, Apple TV, and Nvidia Shield with Arctic Fuse 3. XML validation and whitespace checks pass.