### PR TITLE
:globe_with_meridians: Update Spanish (es_es) translation

### DIFF
--- a/language/resource.language.es_es/strings.po
+++ b/language/resource.language.es_es/strings.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "POT-Creation-Date: 2026-01-12 20:00+0000\n"
-"PO-Revision-Date: 2026-01-13 14:47-0400\n"
+"PO-Revision-Date: 2026-09-07 01:06-0400\n"
 "Last-Translator: 01xKeven\n"
 "Language-Team: \n"
 "Language: es_ES\n"
@@ -501,17 +501,47 @@ msgctxt "#31101"
 msgid "Wall Board"
 msgstr "Mural (Tablero)"
 
+#: /1080i/Includes_DialogInfo.xml
+msgctxt "#31102"
+msgid "Extension"
+msgstr "Extensión"
+
 msgctxt "#31103"
 msgid "Widgets"
 msgstr "Widgets"
+
+#: /1080i/Includes_SkinSettings.xml
+msgctxt "#31104"
+msgid "Position"
+msgstr "Posición"
 
 msgctxt "#31105"
 msgid "Spotlight"
 msgstr "Destacado"
 
+#: /1080i/Includes_Labels.xml
+msgctxt "#31106"
+msgid "Top"
+msgstr "Superior"
+
+#: /1080i/Dialog_DialogGameControllers.xml
+msgctxt "#31107"
+msgid "Edit buttons"
+msgstr "Editar botones"
+
 msgctxt "#31108"
 msgid "Collections"
 msgstr "Colecciones"
+
+#: /1080i/Dialog_DialogPVRGroupManager.xml
+msgctxt "#31109"
+msgid "Edit group"
+msgstr "Editar grupo"
+
+#: /1080i/Includes_Info.xml
+msgctxt "#31110"
+msgid "Starts at"
+msgstr "Comienza a las"
 
 msgctxt "#31111"
 msgid "Row Poster"
@@ -560,10 +590,20 @@ msgctxt "#31120"
 msgid "List Basic"
 msgstr "Lista básica"
 
+#: /1080i/Dialog_FileBrowser.xml
+msgctxt "#31121"
+msgid "Mirror"
+msgstr "Reflejar"
+
 #: /1080i/Includes_MediaFilter.xml
 msgctxt "#31122"
 msgid "Watchlist"
 msgstr "Lista de seguimiento"
+
+#: /1080i/Includes_SkinSettings.xml
+msgctxt "#31123"
+msgid "Plot line"
+msgstr "Línea de argumento"
 
 msgctxt "#31124"
 msgid "Indicator"
@@ -572,6 +612,16 @@ msgstr "Indicador"
 msgctxt "#31125"
 msgid "Invert Text Colour"
 msgstr "Invertir color de texto"
+
+#: /1080i/Includes_SkinSettings.xml
+msgctxt "#31126"
+msgid "Plotline"
+msgstr "Argumento"
+
+#: /1080i/Includes_SkinSettings.xml
+msgctxt "#31127"
+msgid "Genre colours"
+msgstr "Colores por género"
 
 #: /1080i/Includes_MediaFilter.xml
 msgctxt "#31128"
@@ -590,6 +640,16 @@ msgctxt "#31131"
 msgid "Continue watching in"
 msgstr "Seguir viendo en"
 
+#: /shortcuts/skinvariables-splash.json
+msgctxt "#31132"
+msgid "Preloading Hubs"
+msgstr "Precargando hubs"
+
+#: /shortcuts/skinvariables-splash.json
+msgctxt "#31133"
+msgid "Loading Widgets"
+msgstr "Cargando widgets"
+
 #: /1080i/Includes_Labels.xml
 msgctxt "#31134"
 msgid "Playing"
@@ -599,6 +659,11 @@ msgstr "Reproduciendo"
 msgctxt "#31135"
 msgid "Page"
 msgstr "Página"
+
+#: /1080i/Includes_Labels.xml For Spotlight to allow shorter labels which fit
+msgctxt "#31136"
+msgid "Browse"
+msgstr "Explorar"
 
 #: /1080i/SkinSettings.xml /1080i/Includes_Labels.xml
 msgctxt "#31137"
@@ -630,23 +695,63 @@ msgctxt "#31143"
 msgid "Classic"
 msgstr "Clásico"
 
+#: /1080i/Includes_Labels.xml For Spotlight to allow shorter labels which fit
+msgctxt "#31144"
+msgid "Play"
+msgstr "Reproducir"
+
 msgctxt "#31145"
 msgid "Initialising Skin"
 msgstr "Inicializando Skin"
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31146"
+msgid "Onyx"
+msgstr "Ónix"
 
 #: /1080i/Includes_Shortcuts_Window.xml
 msgctxt "#31147"
 msgid "More"
 msgstr "Más"
 
+#: /1080i/Dialog_DialogCustom.xml
+msgctxt "#31148"
+msgid "Black Onyx"
+msgstr "Ónix negro"
+
+#: /1080i/Settings.xml /1080i/SettingsSystemInfo.xml
+msgctxt "#31149"
+msgid "Used memory"
+msgstr "Memoria usada"
+
 #: /1080i/Includes_Labels.xml
 msgctxt "#31150"
 msgid "Categories"
 msgstr "Categorías"
 
+#: /1080i/Settings.xml
+msgctxt "#31151"
+msgid "Customise video info"
+msgstr "Personalizar información de vídeo"
+
+#: /1080i/AddonBrowser.xml
+msgctxt "#31152"
+msgid "Running add-ons"
+msgstr "Add-ons en ejecución"
+
+#: /1080i/Includes_Search.xml
+msgctxt "#31153"
+msgid "Results for"
+msgstr "Resultados para"
+
 msgctxt "#31154"
 msgid "Misc options"
 msgstr "Opciones varias"
+
+#: /1080i/Includes_Search.xml
+msgctxt "#31155"
+msgid "Decades"
+msgstr "Décadas"
 
 #: /1080i/Includes_Keyboard_Mini.xml
 msgctxt "#31158"
@@ -817,7 +922,7 @@ msgctxt "#31207"
 msgid "Codecs"
 msgstr "Códecs"
 
-#: /1080i/SkinSettings.xml /1080i/SkinSettings.xml
+#: /1080i/SkinSettings.xml
 msgctxt "#31208"
 msgid "Header"
 msgstr "Cabecera"
@@ -1069,6 +1174,10 @@ msgctxt "#31272"
 msgid "Searching"
 msgstr "Buscando"
 
+msgctxt "#31273"
+msgid "Label"
+msgstr "Etiqueta"
+
 #: /1080i/Includes_Items.xml
 msgctxt "#31274"
 msgid "Icon"
@@ -1224,10 +1333,10 @@ msgctxt "#31320"
 msgid "Square"
 msgstr "Cuadrado"
 
-#: /1080i/Includes_SkinSettings.xml
+#: /1080i/Includes_SkinSettings.xml /1080i/Settings.xml
 msgctxt "#31321"
-msgid "Select viewtypes"
-msgstr "Seleccionar tipos de vista"
+msgid "Customise viewtypes"
+msgstr "Personalizar tipos de vista"
 
 #: /1080i/SkinSettings.xml /1080i/Includes_Labels.xml
 msgctxt "#31322"
@@ -1635,10 +1744,10 @@ msgctxt "#31432"
 msgid "Adaptive"
 msgstr "Adaptable"
 
-#: /1080i/SkinSettings.xml
+#: /1080i/Includes_SkinSettings.xml /1080i/Settings.xml
 msgctxt "#31434"
-msgid "Video OSD"
-msgstr "OSD de vídeo"
+msgid "Customise video OSD"
+msgstr "Personalizar OSD de vídeo"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31435"
@@ -2254,3 +2363,83 @@ msgstr "Adicional"
 msgctxt "#31605"
 msgid "Next aired"
 msgstr "Próxima emisión"
+
+#: /1080i/Includes_SkinSettings.xml
+msgctxt "#31610"
+msgid "Seasonal Themes"
+msgstr "Temas de temporada"
+
+#: /1080i/Includes_SkinSettings.xml
+msgctxt "#31611"
+msgid "Christmas Theme"
+msgstr "Tema de Navidad"
+
+#: /1080i/Includes_SkinSettings.xml
+msgctxt "#31612"
+msgid "Dec 7 - Jan 7"
+msgstr "7 dic - 7 ene"
+
+#: /1080i/Includes_SkinSettings.xml
+msgctxt "#31613"
+msgid "Winter Frost"
+msgstr "Escarcha invernal"
+
+#: /1080i/Includes_SkinSettings.xml
+msgctxt "#31614"
+msgid "Aussie Christmas"
+msgstr "Navidad australiana"
+
+#: /1080i/Includes_SkinSettings.xml
+msgctxt "#31615"
+msgid "Summer Breeze"
+msgstr "Brisa de verano"
+
+#: /1080i/Includes_SkinSettings.xml
+msgctxt "#31616"
+msgid "Jun 21 - Aug 15"
+msgstr "21 jun - 15 ago"
+
+#: /1080i/Includes_SkinSettings.xml
+msgctxt "#31617"
+msgid "Halloween Spook"
+msgstr "Terror de Halloween"
+
+#: /1080i/Includes_SkinSettings.xml
+msgctxt "#31618"
+msgid "Oct 1 - Nov 1"
+msgstr "1 oct - 1 nov"
+
+#: /1080i/Includes_SkinSettings.xml
+msgctxt "#31619"
+msgid "Background Overlay"
+msgstr "Superposición de fondo"
+
+#: /1080i/Includes_SkinSettings.xml
+msgctxt "#31620"
+msgid "Background Atmosphere"
+msgstr "Ambiente de fondo"
+
+#: /1080i/Includes_SkinSettings.xml
+msgctxt "#31621"
+msgid "Fly-by Animations"
+msgstr "Animaciones de paso"
+
+#: /1080i/Includes_SkinSettings.xml
+msgctxt "#31622"
+msgid "Falling Props Density"
+msgstr "Densidad de elementos en caída"
+
+#: /1080i/Includes_SkinSettings.xml
+msgctxt "#31623"
+msgid "Off"
+msgstr "Desactivado"
+
+#: /1080i/Includes_SkinSettings.xml
+msgctxt "#31624"
+msgid "Normal"
+msgstr "Normal"
+
+#: /1080i/Includes_SkinSettings.xml
+msgctxt "#31625"
+msgid "High"
+msgstr "Alto"


### PR DESCRIPTION
Updates `language/resource.language.es_es/strings.po` to match `en_gb`:

- 38 new strings translated (#31102, #31104, #31106, #31107, #31109, #31110, #31121, #31123, #31126, #31127, #31132, #31133, #31136, #31144, #31146, #31148, #31149, #31151, #31152, #31153, #31155, #31273, #31610-#31625)
- 2 strings updated after source change: #31321 (Customise viewtypes), #31434 (Customise video OSD)
- 0 deleted strings
- Translations follow Kodi wording and this file existing style (Personalizar, hub/widget kept, OSD, Etiqueta, etc.)
- PO-Revision-Date: 2026-09-07, Last-Translator: 01xKeven