### PR TITLE
Add game settings and controller configuration to the Kodi links

### DIFF
--- a/shortcuts/skinvariables-shortcut-config.json
+++ b/shortcuts/skinvariables-shortcut-config.json
@@ -1274,6 +1274,20 @@
             "link": "true"
         },
         {
+            "name": "Game Settings",
+            "path": "ActivateWindow(gamesettings)",
+            "icon": "special://skin/extras/icons/gamepad.png",
+            "link": "true",
+            "rule": "System.GetBool(gamesgeneral.enable)"
+        },
+        {
+            "name": "Controller Configuration",
+            "path": "ActivateWindow(gamecontrollers)",
+            "icon": "special://skin/extras/icons/gamepad.png",
+            "link": "true",
+            "rule": "System.GetBool(gamesgeneral.enable)"
+        },
+        {
             "name": "Event Log",
             "path": "ActivateWindow(eventlog)",
             "icon": "special://skin/extras/icons/list-check.png",


### PR DESCRIPTION
The Miscellaneous group in the shortcut editor covers the file manager, add-on browser, skin settings, interface settings and the event log, but has nothing for games — so a menu item cannot be pointed at either of the two game windows Kodi already provides.

This adds Game Settings and Controller Configuration alongside them, both gated on `System.GetBool(gamesgeneral.enable)` so they disappear rather than leading somewhere inert when game support is turned off.

Uses `extras/icons/gamepad.png`, already in the skin, and the same lowercase `ActivateWindow(gamesettings)` spelling as the settings landing grid.
